### PR TITLE
Nuget doesn't support pre-release suffixes with undescores

### DIFF
--- a/source/OctoVersion.Core/OctoVersionInfo.cs
+++ b/source/OctoVersion.Core/OctoVersionInfo.cs
@@ -31,7 +31,8 @@ namespace OctoVersion.Core
         public string BuildMetadataWithPlus => string.IsNullOrWhiteSpace(BuildMetadata) ? string.Empty : $"+{BuildMetadata}";
         public string FullSemVer => $"{MajorMinorPatch}{PreReleaseTagWithDash}";
         public string InformationalVersion=> $"{MajorMinorPatch}{PreReleaseTagWithDash}{BuildMetadataWithPlus}";
-        public string NuGetVersion => $"{MajorMinorPatch}{PreReleaseTagWithDash.Substring(0, Math.Min(PreReleaseTagWithDash.Length, 20))}";
+        string NuGetCompatiblePreReleaseWithDash => PreReleaseTagWithDash.Substring(0, Math.Min(PreReleaseTagWithDash.Length, 20)).Replace("_", "-");
+        public string NuGetVersion => $"{MajorMinorPatch}{NuGetCompatiblePreReleaseWithDash}";
 
         public override string ToString()
         {

--- a/source/OctoVersion.Tests/WhenStringifyingAnOctoVersionInfo.cs
+++ b/source/OctoVersion.Tests/WhenStringifyingAnOctoVersionInfo.cs
@@ -218,6 +218,12 @@ namespace OctoVersion.Tests
             "mark-genericDocumentStore",
             "Branch.mark-genericDocumentStore.Sha.fb13016f3a21d7c2058fb74ab25f19e5311c6550",
             "2021.1.3-mark-genericDocumen")]
+        [InlineData(2021,
+            1,
+            3,
+            "dependabot/npm_and_yarn/source/TentacleArmy.Web/ini-1.3.6",
+            "Branch.dependabot/npm_and_yarn/source/TentacleArmy.Web/ini-1.3.6.Sha.069392d9d2d37ddb6009998b92e70963badcc666",
+            "2021.1.3-dependabot/npm-and-")]
         public void TheNuGetVersionShouldBeCorrect(int major,
             int minor,
             int patch,


### PR DESCRIPTION
Discovered in the tentacle army [builds](https://build.octopushq.com/buildConfiguration/TentacleArmy_Build/2130042?buildTab=log&focusLine=710&linesState=496.710&logFilter=undefined)