### PR TITLE
Add net5.0 target

### DIFF
--- a/source/Nuke.OctoVersion/Nuke.OctoVersion.csproj
+++ b/source/Nuke.OctoVersion/Nuke.OctoVersion.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
         <Version>0.0.0</Version>
     </PropertyGroup>

--- a/source/OctoVersion.Tests/OctoVersion.Tests.csproj
+++ b/source/OctoVersion.Tests/OctoVersion.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/source/OctoVersion.Tool/OctoVersion.Tool.csproj
+++ b/source/OctoVersion.Tool/OctoVersion.Tool.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>netcoreapp3.1</TargetFramework>
+		<TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
 		<PackAsTool>true</PackAsTool>
 		<ToolCommandName>octoversion</ToolCommandName>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
As we want to:
* remove the `nuke.octoversion` project from OctoVersion
* build OctoVersion support into nuke itself (as requested/recommended by MatKoch (author of nuke))
* support the same frameworks as nuke does

Should be a fairly noddy change.

If it's 💚, should be good to go.