### PR TITLE
Support sane cli args for OutputFormat

### DIFF
--- a/source/OctoVersion.Core/ConfigurationBootstrapper.cs
+++ b/source/OctoVersion.Core/ConfigurationBootstrapper.cs
@@ -38,6 +38,7 @@ namespace OctoVersion.Core
             var appSettings = new T();
             configuration.Bind(appSettings);
 
+            appSettings.ContributeSaneArrayArgs(args);
             appSettings.ApplyDefaultsIfRequired();
 
             return (appSettings, configuration);

--- a/source/OctoVersion.Tests/ConfigurationBootstrapperFixture.cs
+++ b/source/OctoVersion.Tests/ConfigurationBootstrapperFixture.cs
@@ -1,0 +1,144 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using OctoVersion.Core;
+using OctoVersion.Core.Configuration;
+using Shouldly;
+using Xunit;
+
+namespace OctoVersion.Tests
+{
+    public class ConfigurationBootstrapperFixture : IDisposable
+    {
+        public void Dispose()
+        {
+            foreach (DictionaryEntry environmentVariable in Environment.GetEnvironmentVariables())
+            {
+                var key = (string)environmentVariable.Key;
+                if (key.StartsWith(ConfigurationBootstrapper.EnvironmentVariablePrefix))
+                    Environment.SetEnvironmentVariable(key, "");
+            }
+        }
+
+        [Fact]
+        public void ThrowsExceptionWhenNoArgsArePassed()
+        {
+            var args = new string[0];
+            var ex = Assert.Throws<ValidationException>(() => ConfigurationBootstrapper.Bootstrap<AppSettings>(args));
+            ex.Message.ShouldBe("At least one of CurrentBranch or FullSemVer must be provided.");
+        }
+
+        [Fact]
+        public void WhenPassingCurrentBranch()
+        {
+            var args = new[] { "--CurrentBranch", "main" };
+            var (appSettings, _) = ConfigurationBootstrapper.Bootstrap<AppSettings>(args);
+            appSettings.CurrentBranch.ShouldBe("main");
+            appSettings.NonPreReleaseTags.ShouldBeEquivalentTo(new [] { "main", "master" }); //defaults should be applied
+            appSettings.OutputFormats.ShouldBeEquivalentTo(new [] { "Console" }); //defaults should be applied
+        }
+
+        [Fact]
+        public void WhenPassingFullSemVer()
+        {
+            var args = new[] { "--FullSemVer", "1.0.0" };
+            var (appSettings, _) = ConfigurationBootstrapper.Bootstrap<AppSettings>(args);
+            appSettings.FullSemVer.ShouldBe("1.0.0");
+            appSettings.NonPreReleaseTags.ShouldBeEquivalentTo(new [] { "main", "master" }); //defaults should be applied
+            appSettings.OutputFormats.ShouldBeEquivalentTo(new [] { "Console" }); //defaults should be applied
+        }
+
+        [Theory]
+        [MemberData(nameof(OutputFormatTestCases))]
+        public void WhenPassingOutputFormats(string[] args, string[] expectedOutputFormats)
+        {
+            var fullArgs = new [] { "--CurrentBranch", "main" }.Concat(args).ToArray();
+            var (appSettings, _) = ConfigurationBootstrapper.Bootstrap<AppSettings>(fullArgs);
+            appSettings.OutputFormats.ShouldBeEquivalentTo(expectedOutputFormats);
+        }
+
+        public static IEnumerable<object[]> OutputFormatTestCases()
+        {
+            // sane formats
+            yield return new object[] { new [] { "--outputformat", "json" }, new [] { "json" } };
+            yield return new object[] { new [] { "--outputformat", "json", "--outputformat", "console" }, new [] { "json", "console" } };
+
+            // dotnet configuration formats
+            yield return new object[] { new [] { "--outputformat:0", "json" }, new [] { "json" } };
+            yield return new object[] { new [] { "--outputformat:0", "json", "--outputformat:1", "console" }, new [] { "json", "console" } };
+        }
+
+        [Theory]
+        [MemberData(nameof(OutputFormatEnvironmentVariableTestCases))]
+        public void WhenPassingOutputFormatsViaEnvironmentVariable((string Name, string Value)[] environmentVariables, string[] expectedOutputFormats)
+        {
+            Environment.SetEnvironmentVariable("OCTOVERSION_CurrentBranch", "main");
+            foreach (var (name, value) in environmentVariables)
+                Environment.SetEnvironmentVariable(name, value);
+            var (appSettings, _) = ConfigurationBootstrapper.Bootstrap<AppSettings>();
+            appSettings.OutputFormats.ShouldBeEquivalentTo(expectedOutputFormats);
+        }
+
+        public static IEnumerable<object[]> OutputFormatEnvironmentVariableTestCases()
+        {
+            yield return new object[]
+            {
+                new[] { new ValueTuple<string, string>("OCTOVERSION_OutputFormats__0", "main") },
+                new [] { "main" }
+            };
+            yield return new object[]
+            {
+                new[] { new ValueTuple<string, string>( "OCTOVERSION_OutputFormats__0", "main"), new ValueTuple<string, string> ("OCTOVERSION_OutputFormats__1", "release") },
+                new [] { "main", "release" }
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(NonPreReleaseTagsTestCases))]
+        public void WhenPassingNonPreReleaseTags(string[] args, string[] expectedNonPreReleaseTags)
+        {
+            var fullArgs = new [] { "--CurrentBranch", "main" }.Concat(args).ToArray();
+            var (appSettings, _) = ConfigurationBootstrapper.Bootstrap<AppSettings>(fullArgs);
+            appSettings.NonPreReleaseTags.ShouldBeEquivalentTo(expectedNonPreReleaseTags);
+        }
+
+        public static IEnumerable<object[]> NonPreReleaseTagsTestCases()
+        {
+            // sane formats
+            yield return new object[] { new [] { "--nonprereleasetags", "main" }, new [] { "main" } };
+            yield return new object[] { new [] { "--nonprereleasetags", "main", "--nonprereleasetags", "release" }, new [] { "main", "release" } };
+
+            // dotnet configuration formats
+            yield return new object[] { new [] { "--nonprereleasetags:0", "main" }, new [] { "main" } };
+            yield return new object[] { new [] { "--nonprereleasetags:0", "main", "--nonprereleasetags:1", "release" }, new [] { "main", "release" } };
+        }
+
+        [Theory]
+        [MemberData(nameof(NonPreReleaseTagsEnvironmentVariableTestCases))]
+        public void WhenPassingNonPreReleaseTagsViaEnvironmentVariable((string Name, string Value)[] environmentVariables, string[] expectedNonPreReleaseTags)
+        {
+            Environment.SetEnvironmentVariable("OCTOVERSION_CurrentBranch", "main");
+            foreach (var (name, value) in environmentVariables)
+                Environment.SetEnvironmentVariable(name, value);
+
+            var (appSettings, _) = ConfigurationBootstrapper.Bootstrap<AppSettings>();
+            appSettings.NonPreReleaseTags.ShouldBeEquivalentTo(expectedNonPreReleaseTags);
+        }
+
+        public static IEnumerable<object[]> NonPreReleaseTagsEnvironmentVariableTestCases()
+        {
+            yield return new object[]
+            {
+                new[] { new ValueTuple<string, string>("OCTOVERSION_NonPreReleaseTags__0", "main") },
+                new [] { "main" }
+            };
+            yield return new object[]
+            {
+                new[] { new ValueTuple<string, string>( "OCTOVERSION_NonPreReleaseTags__0", "main"), new ValueTuple<string, string> ("OCTOVERSION_NonPreReleaseTags__1", "release") },
+                new [] { "main", "release" }
+            };
+        }
+    }
+}

--- a/source/OctoVersion.Tests/octoversion.json
+++ b/source/OctoVersion.Tests/octoversion.json
@@ -1,0 +1,3 @@
+{
+  //empty configuration file to prevent the real octoversion.json in the root from affecting the tests
+}


### PR DESCRIPTION
So that nuke can consume it without bending over backwards with dotnet's weird array arg syntax

dotnet treats command line args as a dictionary - each key must be unique.
This is a bit weird considering most other tools say "pass the arg multiple times" when dealing with an array typed parameter.

Instead of going
```
octoversion --outputformat json
```
you have to go
```
octoversion --outputformat:0 json
```

This PR:
* keeps the existing behavior (to avoid breaking things)
* adds support for sane array parameter parsing from the CLI
* adds tests to ensure that old and new approaches work

Note: the environment variable approach still needs to use existing approach, ie `OCTOVERSION_OutputFormats__0` to pass values.