### PR TITLE
Allow `v` Prefix on Tag Versions

### DIFF
--- a/source/OctoVersion.Core/VersionNumberCalculation/SimpleVersion.cs
+++ b/source/OctoVersion.Core/VersionNumberCalculation/SimpleVersion.cs
@@ -34,6 +34,11 @@ namespace OctoVersion.Core.VersionNumberCalculation
         {
             try
             {
+                if (versionString.StartsWith("v"))
+                {
+                    versionString = versionString.Substring(1);
+                }
+
                 var indexOfEndOfDigits = versionString.IndexOfAny("-+".ToCharArray());
                 if (indexOfEndOfDigits > 0)
                 {

--- a/source/OctoVersion.Tests/WhenParsingASimpleVersion.cs
+++ b/source/OctoVersion.Tests/WhenParsingASimpleVersion.cs
@@ -27,6 +27,8 @@ namespace OctoVersion.Tests
             yield return new object[] { "1+some-build-info", new SimpleVersion(1, 0, 0) };
             yield return new object[] { "1.2+some-build-info", new SimpleVersion(1, 2, 0) };
             yield return new object[] { "1.2.3+some-build-info", new SimpleVersion(1, 2, 3) };
+            yield return new object[] { "v0.1.0", new SimpleVersion(0, 1, 0) };
+            yield return new object[] { "x0.1.0", null };
         }
     }
 }


### PR DESCRIPTION
In our workflow we use version tags of the form
`v{major}.{minor}.{patch}`. This change allows OctoVersion to correctly
identify the version at those tagged commits.