### PR TITLE
Make pre release tag and build metadata match semver2 spec

### DIFF
--- a/source/OctoVersion.Core/OctoVersionInfo.cs
+++ b/source/OctoVersion.Core/OctoVersionInfo.cs
@@ -1,9 +1,15 @@
 ﻿using System;
+using System.Text.RegularExpressions;
 
 namespace OctoVersion.Core
 {
     public class OctoVersionInfo : SemanticVersion
     {
+        //https://semver.org/spec/v2.0.0.html#spec-item-9
+        static readonly Regex InvalidPreReleaseCharacters = new Regex("[^0-9A-Za-z-\\.]", RegexOptions.Compiled);
+        //https://semver.org/spec/v2.0.0.html#spec-item-10
+        static readonly Regex InvalidBuildMetadataCharacters = new Regex("[^0-9A-Za-z-\\.]", RegexOptions.Compiled);
+
         public OctoVersionInfo(
             int major,
             int minor,
@@ -26,12 +32,12 @@ namespace OctoVersion.Core
         {
         }
 
-        public string PreReleaseTagWithDash => string.IsNullOrWhiteSpace(PreReleaseTag) ? string.Empty : $"-{PreReleaseTag}";
+        public string PreReleaseTagWithDash => string.IsNullOrWhiteSpace(PreReleaseTag) ? string.Empty : $"-{InvalidPreReleaseCharacters.Replace(PreReleaseTag, "-")}";
         public string MajorMinorPatch => $"{Major}.{Minor}.{Patch}";
-        public string BuildMetadataWithPlus => string.IsNullOrWhiteSpace(BuildMetadata) ? string.Empty : $"+{BuildMetadata}";
+        public string BuildMetadataWithPlus => string.IsNullOrWhiteSpace(BuildMetadata) ? string.Empty : $"+{InvalidBuildMetadataCharacters.Replace(BuildMetadata, "-")}";
         public string FullSemVer => $"{MajorMinorPatch}{PreReleaseTagWithDash}";
         public string InformationalVersion => $"{MajorMinorPatch}{PreReleaseTagWithDash}{BuildMetadataWithPlus}";
-        string NuGetCompatiblePreReleaseWithDash => PreReleaseTagWithDash.Substring(0, Math.Min(PreReleaseTagWithDash.Length, 20)).Replace("_", "-");
+        string NuGetCompatiblePreReleaseWithDash => PreReleaseTagWithDash.Substring(0, Math.Min(PreReleaseTagWithDash.Length, 20));
         public string NuGetVersion => $"{MajorMinorPatch}{NuGetCompatiblePreReleaseWithDash}";
 
         public override string ToString()

--- a/source/OctoVersion.Tests/WhenStringifyingAnOctoVersionInfo.cs
+++ b/source/OctoVersion.Tests/WhenStringifyingAnOctoVersionInfo.cs
@@ -24,7 +24,7 @@ namespace OctoVersion.Tests
             yield return new object[] { VersionWithPreReleaseTag, "-pre", "it should append the pre-release tag" };
             yield return new object[] { VersionWithPreReleaseTagAndBuildMetadata, "-pre", "it should append the pre-release tag, but not the build metadata" };
             yield return new object[] { VersionWithLongPreReleaseTagAndBuildMetadata, "-mark-genericDocumentStore", "it should add the pre-release tag, and ignore the build metadata" };
-            yield return new object[] { VersionWithLongPreReleaseTagWithSlashesAndBuildMetadata, "-dependabot/npm_and_yarn/source/TentacleArmy.Web/ini-1.3.6", "it should add the pre-release tag, and ignore the build metadata" };
+            yield return new object[] { VersionWithLongPreReleaseTagWithSlashesAndBuildMetadata, "-dependabot-npm-and-yarn-source-TentacleArmy.Web-ini-1.3.6", "it should add the pre-release tag, and ignore the build metadata" };
         }
 
         [Theory]
@@ -60,7 +60,7 @@ namespace OctoVersion.Tests
             yield return new object[] { VersionWithPreReleaseTag, "", "there is no build metadata" };
             yield return new object[] { VersionWithPreReleaseTagAndBuildMetadata, "+build", "it should return the build metadata" };
             yield return new object[] { VersionWithLongPreReleaseTagAndBuildMetadata, "+Branch.mark-genericDocumentStore.Sha.fb13016f3a21d7c2058fb74ab25f19e5311c6550", "it should return the build metadata" };
-            yield return new object[] { VersionWithLongPreReleaseTagWithSlashesAndBuildMetadata, "+Branch.dependabot/npm_and_yarn/source/TentacleArmy.Web/ini-1.3.6.Sha.069392d9d2d37ddb6009998b92e70963badcc666", "it should return the build metadata" };
+            yield return new object[] { VersionWithLongPreReleaseTagWithSlashesAndBuildMetadata, "+Branch.dependabot-npm-and-yarn-source-TentacleArmy.Web-ini-1.3.6.Sha.069392d9d2d37ddb6009998b92e70963badcc666", "it should return the build metadata" };
         }
 
         [Theory]
@@ -78,7 +78,7 @@ namespace OctoVersion.Tests
             yield return new object[] { VersionWithPreReleaseTag, "1.2.3-pre", "it should return the major.minor.patch and pre-release" };
             yield return new object[] { VersionWithPreReleaseTagAndBuildMetadata, "1.2.3-pre", "it should return the major.minor.patch and pre-release but not the build metadata" };
             yield return new object[] { VersionWithLongPreReleaseTagAndBuildMetadata, "2021.1.3-mark-genericDocumentStore", "it should return the major.minor.patch and pre-release but not the build metadata" };
-            yield return new object[] { VersionWithLongPreReleaseTagWithSlashesAndBuildMetadata, "2021.1.3-dependabot/npm_and_yarn/source/TentacleArmy.Web/ini-1.3.6", "it should return the major.minor.patch and pre-release but not the build metadata" };
+            yield return new object[] { VersionWithLongPreReleaseTagWithSlashesAndBuildMetadata, "2021.1.3-dependabot-npm-and-yarn-source-TentacleArmy.Web-ini-1.3.6", "it should return the major.minor.patch and pre-release but not the build metadata" };
         }
 
         [Theory]
@@ -96,7 +96,7 @@ namespace OctoVersion.Tests
             yield return new object[] { VersionWithPreReleaseTag, "1.2.3-pre", "it should append the pre-release tag" };
             yield return new object[] { VersionWithPreReleaseTagAndBuildMetadata, "1.2.3-pre", "it should return the major.minor.patch and pre-release but not the build metadata" };
             yield return new object[] { VersionWithLongPreReleaseTagAndBuildMetadata, "2021.1.3-mark-genericDocumen", "it should return the major.minor.patch and trim the pre-release to 20 chars" };
-            yield return new object[] { VersionWithLongPreReleaseTagWithSlashesAndBuildMetadata, "2021.1.3-dependabot/npm-and-", "it should return the major.minor.patch and trim the pre-release to 20 chars" };
+            yield return new object[] { VersionWithLongPreReleaseTagWithSlashesAndBuildMetadata, "2021.1.3-dependabot-npm-and-", "it should return the major.minor.patch and trim the pre-release to 20 chars" };
         }
 
         [Theory]
@@ -114,7 +114,7 @@ namespace OctoVersion.Tests
             yield return new object[] { VersionWithPreReleaseTag, "1.2.3-pre", "it should append the pre-release tag" };
             yield return new object[] { VersionWithPreReleaseTagAndBuildMetadata, "1.2.3-pre+build", "it should return the major.minor.patch and pre-release and build metadata" };
             yield return new object[] { VersionWithLongPreReleaseTagAndBuildMetadata, "2021.1.3-mark-genericDocumentStore+Branch.mark-genericDocumentStore.Sha.fb13016f3a21d7c2058fb74ab25f19e5311c6550", "it should return the major.minor.patch and pre-release and build metadata" };
-            yield return new object[] { VersionWithLongPreReleaseTagWithSlashesAndBuildMetadata, "2021.1.3-dependabot/npm_and_yarn/source/TentacleArmy.Web/ini-1.3.6+Branch.dependabot/npm_and_yarn/source/TentacleArmy.Web/ini-1.3.6.Sha.069392d9d2d37ddb6009998b92e70963badcc666", "it should return the major.minor.patch and pre-release and build metadata" };
+            yield return new object[] { VersionWithLongPreReleaseTagWithSlashesAndBuildMetadata, "2021.1.3-dependabot-npm-and-yarn-source-TentacleArmy.Web-ini-1.3.6+Branch.dependabot-npm-and-yarn-source-TentacleArmy.Web-ini-1.3.6.Sha.069392d9d2d37ddb6009998b92e70963badcc666", "it should return the major.minor.patch and pre-release and build metadata" };
         }
 
         [Theory]


### PR DESCRIPTION
We were allowing underscores and slashes in these fields, which is not supported according to the spec https://semver.org/spec/v2.0.0.html.

Keen for thoughts around whether this is too much of a breaking change / whether we should be exposing a "semver1" and "semver2" versions in some way.