### PR TITLE
Support auto-detection of output formats based on runtime environment

### DIFF
--- a/source/Cake.OctoVersion/Logging/CakeOutputFormatter.cs
+++ b/source/Cake.OctoVersion/Logging/CakeOutputFormatter.cs
@@ -17,10 +17,13 @@ namespace Cake.OctoVersion.Logging
         }
 
         public ILogEventSink LogSink { get; }
+        public string Name => "Cake";
 
         public void Write(OctoVersionInfo octoVersionInfo)
         {
             context.Log.Information(octoVersionInfo);
         }
+
+        public bool MatchesRuntimeEnvironment() => false;
     }
 }

--- a/source/OctoVersion.Core/Configuration/AppSettings.cs
+++ b/source/OctoVersion.Core/Configuration/AppSettings.cs
@@ -33,10 +33,12 @@ namespace OctoVersion.Core.Configuration
 
         public string[] OutputFormats { get; set; } = Array.Empty<string>();
 
+        public bool DetectEnvironment { get; set; }
+
         public void ApplyDefaultsIfRequired()
         {
-            if (!NonPreReleaseTags.Any()) NonPreReleaseTags = new[] { "main", "master" };
-            if (!OutputFormats.Any()) OutputFormats = new[] { "Console" };
+            if (!NonPreReleaseTags.Any())
+                NonPreReleaseTags = new[] { "main", "master" };
         }
 
         /// <param name="strings"></param>

--- a/source/OctoVersion.Core/IOutputFormatter.cs
+++ b/source/OctoVersion.Core/IOutputFormatter.cs
@@ -6,6 +6,8 @@ namespace OctoVersion.Core
     public interface IOutputFormatter
     {
         ILogEventSink LogSink { get; }
+        string Name { get; }
         void Write(OctoVersionInfo octoVersionInfo);
+        bool MatchesRuntimeEnvironment();
     }
 }

--- a/source/OctoVersion.Core/OctoVersionRunner.cs
+++ b/source/OctoVersion.Core/OctoVersionRunner.cs
@@ -32,7 +32,7 @@ namespace OctoVersion.Core
 
         public void Run(out OctoVersionInfo versionInfo)
         {
-            var outputFormatters = new OutputFormattersProvider().GetFormatters(appSettings.OutputFormats);
+            var outputFormatters = new OutputFormattersProvider().GetFormatters(appSettings);
             LogBootstrapper.Bootstrap(configuration,
                 lc =>
                 {

--- a/source/OctoVersion.Core/OutputFormatting/Console/ConsoleOutputFormatter.cs
+++ b/source/OctoVersion.Core/OutputFormatting/Console/ConsoleOutputFormatter.cs
@@ -7,10 +7,13 @@ namespace OctoVersion.Core.OutputFormatting.Console
     class ConsoleOutputFormatter : IOutputFormatter
     {
         public ILogEventSink LogSink { get; } = new NullSink();
+        public string Name => "Console";
 
         public void Write(OctoVersionInfo octoVersionInfo)
         {
             System.Console.WriteLine(octoVersionInfo);
         }
+
+        public bool MatchesRuntimeEnvironment() => false;
     }
 }

--- a/source/OctoVersion.Core/OutputFormatting/Console/QuietConsoleOutputFormatter.cs
+++ b/source/OctoVersion.Core/OutputFormatting/Console/QuietConsoleOutputFormatter.cs
@@ -7,10 +7,13 @@ namespace OctoVersion.Core.OutputFormatting.Console
     class QuietConsoleOutputFormatter : IOutputFormatter
     {
         public ILogEventSink LogSink { get; } = new NullSink();
+        public string Name => "QuietConsole";
 
         public void Write(OctoVersionInfo octoVersionInfo)
         {
             System.Console.WriteLine(octoVersionInfo);
         }
+
+        public bool MatchesRuntimeEnvironment() => false;
     }
 }

--- a/source/OctoVersion.Core/OutputFormatting/Environment/EnvironmentOutputFormatter.cs
+++ b/source/OctoVersion.Core/OutputFormatting/Environment/EnvironmentOutputFormatter.cs
@@ -8,6 +8,7 @@ namespace OctoVersion.Core.OutputFormatting.Environment
     public class EnvironmentOutputFormatter : IOutputFormatter
     {
         public ILogEventSink LogSink { get; } = new NullSink();
+        public string Name => "Environment";
 
         public void Write(OctoVersionInfo octoVersionInfo)
         {
@@ -23,5 +24,7 @@ namespace OctoVersion.Core.OutputFormatting.Environment
                 System.Console.WriteLine(line);
             }
         }
+
+        public bool MatchesRuntimeEnvironment() => false;
     }
 }

--- a/source/OctoVersion.Core/OutputFormatting/Json/JsonOutputFormatter.cs
+++ b/source/OctoVersion.Core/OutputFormatting/Json/JsonOutputFormatter.cs
@@ -13,11 +13,14 @@ namespace OctoVersion.Core.OutputFormatting.Json
         };
 
         public ILogEventSink LogSink { get; } = new NullSink();
+        public string Name => "Json";
 
         public void Write(OctoVersionInfo octoVersionInfo)
         {
             var json = JsonConvert.SerializeObject(octoVersionInfo, Settings);
             System.Console.WriteLine(json);
         }
+
+        public bool MatchesRuntimeEnvironment() => false;
     }
 }

--- a/source/OctoVersion.Core/OutputFormatting/TeamCity/TeamCityOutputFormatter.cs
+++ b/source/OctoVersion.Core/OutputFormatting/TeamCity/TeamCityOutputFormatter.cs
@@ -7,12 +7,15 @@ namespace OctoVersion.Core.OutputFormatting.TeamCity
     public class TeamCityOutputFormatter : IOutputFormatter
     {
         public ILogEventSink LogSink { get; } = new TeamCityLogSink();
+        public string Name => "TeamCity";
 
         public void Write(OctoVersionInfo octoVersionInfo)
         {
             WriteBuildNumber(octoVersionInfo);
             WriteEnvironmentVariables(octoVersionInfo);
         }
+
+        public bool MatchesRuntimeEnvironment() => !string.IsNullOrEmpty(System.Environment.GetEnvironmentVariable("TEAMCITY_VERSION"));
 
         static void WriteBuildNumber(OctoVersionInfo octoVersionInfo)
         {

--- a/source/OctoVersion.Tests/ConfigurationBootstrapperFixture.cs
+++ b/source/OctoVersion.Tests/ConfigurationBootstrapperFixture.cs
@@ -38,7 +38,6 @@ namespace OctoVersion.Tests
             var (appSettings, _) = ConfigurationBootstrapper.Bootstrap<AppSettings>(args);
             appSettings.CurrentBranch.ShouldBe("main");
             appSettings.NonPreReleaseTags.ShouldBeEquivalentTo(new[] { "main", "master" }); //defaults should be applied
-            appSettings.OutputFormats.ShouldBeEquivalentTo(new[] { "Console" }); //defaults should be applied
         }
 
         [Fact]
@@ -48,7 +47,6 @@ namespace OctoVersion.Tests
             var (appSettings, _) = ConfigurationBootstrapper.Bootstrap<AppSettings>(args);
             appSettings.FullSemVer.ShouldBe("1.0.0");
             appSettings.NonPreReleaseTags.ShouldBeEquivalentTo(new[] { "main", "master" }); //defaults should be applied
-            appSettings.OutputFormats.ShouldBeEquivalentTo(new[] { "Console" }); //defaults should be applied
         }
 
         [Theory]

--- a/source/OctoVersion.Tests/OutputFormattersProviderFixture.cs
+++ b/source/OctoVersion.Tests/OutputFormattersProviderFixture.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections;
+using System.Linq;
+using OctoVersion.Core;
+using OctoVersion.Core.Configuration;
+using Shouldly;
+using Xunit;
+
+namespace OctoVersion.Tests
+{
+    [Collection("TheseTestsModifyEnvironmentVariables")] //Cant run these in parallel, as they modify global state (environment variables)
+    public class OutputFormattersProviderFixture : IDisposable
+    {
+        readonly string? originalTeamCityVersionEnvVar;
+
+        public OutputFormattersProviderFixture()
+        {
+            originalTeamCityVersionEnvVar = Environment.GetEnvironmentVariable("TEAMCITY_VERSION");
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable("TEAMCITY_VERSION", originalTeamCityVersionEnvVar);
+        }
+
+        [Fact]
+        public void DefaultsToConsoleIfNoneRequested()
+        {
+            var appSettings = new AppSettings
+            {
+                DetectEnvironment = false,
+                OutputFormats = Array.Empty<string>()
+            };
+            var results = new OutputFormattersProvider().GetFormatters(appSettings).Select(x => x.Name).ToArray();
+            results.ShouldBeEquivalentTo(new [] { "Console" }, "it should default to safe and show some output");
+        }
+
+        [Fact]
+        public void UsesRequestedOutputFormatter()
+        {
+            var appSettings = new AppSettings
+            {
+                DetectEnvironment = false,
+                OutputFormats = new [] { "Json" }
+            };
+            var results = new OutputFormattersProvider().GetFormatters(appSettings).Select(x => x.Name).ToArray();
+            results.ShouldBeEquivalentTo(new [] { "Json" }, "it should use the requested output format");
+        }
+
+        [Fact]
+        public void SupportsMultipleRequestedOutputFormatter()
+        {
+            var appSettings = new AppSettings
+            {
+                DetectEnvironment = false,
+                OutputFormats = new [] { "Json", "Environment" }
+            };
+            var results = new OutputFormattersProvider().GetFormatters(appSettings).Select(x => x.Name).ToArray();
+            results.ShouldBeEquivalentTo(new [] { "Json", "Environment" }, "it should allow multiple output formats");
+        }
+
+        [Fact]
+        public void DetectsTeamCityFromEnvironmentIfRequested()
+        {
+            Environment.SetEnvironmentVariable("TEAMCITY_VERSION", "1.2.3");
+            var appSettings = new AppSettings
+            {
+                DetectEnvironment = true,
+                OutputFormats = new [] { "Json" }
+            };
+            var results = new OutputFormattersProvider().GetFormatters(appSettings).Select(x => x.Name).ToArray();
+            results.ShouldBeEquivalentTo(new [] { "TeamCity" }, "it should have prioritised auto-detection over the provided value");
+        }
+    }
+}


### PR DESCRIPTION
Relates to https://github.com/nuke-build/nuke/pull/778.

We want to add auto-detection of output formats so that we dont have to hardcode the output format into either nuke or build scripts