### PR TITLE
Update to the latest pre-release of LibGit2Sharp

### DIFF
--- a/source/OctoVersion.Core/OctoVersion.Core.csproj
+++ b/source/OctoVersion.Core/OctoVersion.Core.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="LibGit2Sharp" Version="0.26.2" />
+		<PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0116" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0" />


### PR DESCRIPTION
This allows us to run OctoVersion in GitHub Actions, when we're using Ubuntu 20.0