### PR TITLE
Throw a nice error if it's a shallow clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ artifacts
 TestResults
 .idea/
 .nuke/temp/
+.DS_Store

--- a/source/OctoVersion.Core/Exceptions/ControlledFailureException.cs
+++ b/source/OctoVersion.Core/Exceptions/ControlledFailureException.cs
@@ -1,0 +1,26 @@
+using System;
+
+namespace OctoVersion.Core.Exceptions
+{
+    /// <summary>
+    /// A controlled failure is one where the task at hand must be aborted
+    /// but we do not need to reveal additional stack trace information to
+    /// the user, 
+    /// </summary>
+    /// <remarks>
+    /// ONLY throw this exception if you're 100% certain that a stack trace
+    /// won't be useful to the user (or us) when they try to diagnose the issue.
+    /// </remarks>
+    public class ControlledFailureException : Exception
+    {
+        public ControlledFailureException(string message)
+            : base(message)
+        {
+        }
+
+        public ControlledFailureException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/source/OctoVersion.Core/Exceptions/RepositoryIsShallowCloneException.cs
+++ b/source/OctoVersion.Core/Exceptions/RepositoryIsShallowCloneException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace OctoVersion.Core.Exceptions
+{
+    public class RepositoryIsShallowCloneException : ControlledFailureException
+    {
+        public RepositoryIsShallowCloneException(string message) : base(message)
+        {
+        }
+
+        public RepositoryIsShallowCloneException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/source/OctoVersion.Core/Exceptions/RepositoryNotFoundException.cs
+++ b/source/OctoVersion.Core/Exceptions/RepositoryNotFoundException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace OctoVersion.Core.Exceptions
+{
+    public class RepositoryNotFoundException : ControlledFailureException
+    {
+        public RepositoryNotFoundException(string message) : base(message)
+        {
+        }
+
+        public RepositoryNotFoundException(string message, Exception innerException) : base(message, innerException)
+        {
+        }
+    }
+}

--- a/source/OctoVersion.Tool/Program.cs
+++ b/source/OctoVersion.Tool/Program.cs
@@ -1,17 +1,35 @@
 ﻿using System;
 using OctoVersion.Core;
 using OctoVersion.Core.Configuration;
+using OctoVersion.Core.Exceptions;
+using OctoVersion.Core.VersionNumberCalculation;
+using Serilog;
 
 namespace OctoVersion.Tool
 {
     class Program
     {
-        static void Main(string[] args)
+        static int Main(string[] args)
         {
             var (appSettings, configuration) = ConfigurationBootstrapper.Bootstrap<AppSettings>(args);
 
             var runner = new OctoVersionRunner(appSettings, configuration);
-            runner.Run(out _);
+            try
+            {
+                runner.Run(out _);
+            }
+            catch (ControlledFailureException ex)
+            {
+                Log.Error("{Message}", ex.Message);
+                return 1;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "{Message}",ex.Message);
+                return 1;
+            }
+
+            return 0;
         }
     }
 }


### PR DESCRIPTION
If it's a shallow clone, then we cant look through the history to determine the version number

This would've helped resolve this error

![image](https://user-images.githubusercontent.com/373389/152924633-d4db2352-76ec-4d5e-a42e-99fb862b492c.png)

Shallow clone shows errors like this:
![image](https://user-images.githubusercontent.com/373389/152924861-943130d1-d4af-4a45-ad3c-1d7eb1e60e5d.png)


"Unexpected" errors show like this:
![image](https://user-images.githubusercontent.com/373389/152924810-50ca0941-fe05-4f33-9d3d-f923a19fca11.png)

