### PR TITLE
Fix resharper warnings about log messages

### DIFF
--- a/source/OctoVersion.Core/OctoVersionRunner.cs
+++ b/source/OctoVersion.Core/OctoVersionRunner.cs
@@ -51,7 +51,7 @@ namespace OctoVersion.Core
 
             if (!string.IsNullOrWhiteSpace(appSettings.FullSemVer))
             {
-                Log.Information("Adopting previously-provided version information {FullSemVer}. Not calculating a new version number.", appSettings.FullSemVer);
+                Log.Information("Adopting previously-provided version information {FullSemVer}; not calculating a new version number;", appSettings.FullSemVer);
                 var semanticVersion = SemanticVersion.TryParse(appSettings.FullSemVer);
                 if (semanticVersion == null) throw new Exception("Failed to parse semantic version string");
 

--- a/source/OctoVersion.Core/StructuredOutputFactory.cs
+++ b/source/OctoVersion.Core/StructuredOutputFactory.cs
@@ -94,7 +94,7 @@ namespace OctoVersion.Core
             if (_nonPreReleaseTags.Any(t => t.Equals(_currentBranch, StringComparison.OrdinalIgnoreCase)))
             {
                 _logger.Debug(
-                    "{CurrentBranch} is contained within the set of non-pre-release branches {@NonPreReleaseBranches}. No pre-release tag is being added.",
+                    "{CurrentBranch} is contained within the set of non-pre-release branches {@NonPreReleaseBranches}; no pre-release tag is being added",
                     _currentBranch,
                     _nonPreReleaseTags);
                 return string.Empty;
@@ -102,12 +102,12 @@ namespace OctoVersion.Core
 
             if (!string.IsNullOrWhiteSpace(_nonPreReleaseTagsRegex))
             {
-                _logger.Debug("A non-pre-release regular expression has been provided. Checking against that.");
+                _logger.Debug("A non-pre-release regular expression has been provided; checking against that");
                 var regex = new Regex(_nonPreReleaseTagsRegex, RegexOptions.Compiled);
                 if (regex.IsMatch(_currentBranch))
                 {
                     _logger.Debug(
-                        "{CurrentBranch} matches the non-pre-release regular expression {NonPreReleaseTagsRegularExpression}. No pre-release tag is being added.",
+                        "{CurrentBranch} matches the non-pre-release regular expression {NonPreReleaseTagsRegularExpression}; no pre-release tag is being added",
                         _currentBranch,
                         _nonPreReleaseTagsRegex);
                     return string.Empty;


### PR DESCRIPTION
We were getting errors:
```
Log event messages should be fragments, not sentences. Avoid a trailing period/full stop.
```
(hah! it contains a trailing full stop!)