### PR TITLE
Fix up all remaining warnings

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -7,6 +7,7 @@
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
     <NukeScriptDirectory>..</NukeScriptDirectory>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Cake.OctoVersion/Cake.OctoVersion.csproj
+++ b/source/Cake.OctoVersion/Cake.OctoVersion.csproj
@@ -4,6 +4,7 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Version>0.0.0</Version>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/source/OctoVersion.Core/OctoVersion.Core.csproj
+++ b/source/OctoVersion.Core/OctoVersion.Core.csproj
@@ -6,6 +6,8 @@
 		<Nullable>enable</Nullable>
 		<Version>0.0.0</Version>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<NoWarn>1701;1702;NU5104</NoWarn>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/source/OctoVersion.Tests/ConfigurationBootstrapperFixture.cs
+++ b/source/OctoVersion.Tests/ConfigurationBootstrapperFixture.cs
@@ -15,12 +15,15 @@ namespace OctoVersion.Tests
     {
         public void Dispose()
         {
-            foreach (DictionaryEntry environmentVariable in Environment.GetEnvironmentVariables())
-            {
-                var key = (string)environmentVariable.Key;
-                if (key.StartsWith(ConfigurationBootstrapper.EnvironmentVariablePrefix))
-                    Environment.SetEnvironmentVariable(key, "");
-            }
+            var envVars = Environment.GetEnvironmentVariables()
+                .Cast<object?>()
+                .Where(environmentVariable => environmentVariable != null)
+                .Select(environmentVariable => (DictionaryEntry)environmentVariable!)
+                .Select(envVar => (string)envVar.Key)
+                .Where(key => key.StartsWith(ConfigurationBootstrapper.EnvironmentVariablePrefix));
+
+            foreach (var key in envVars)
+                Environment.SetEnvironmentVariable(key, "");
         }
 
         [Fact]

--- a/source/OctoVersion.Tests/OctoVersion.Tests.csproj
+++ b/source/OctoVersion.Tests/OctoVersion.Tests.csproj
@@ -5,6 +5,7 @@
     <LangVersion>10</LangVersion>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/OctoVersion.Tests/SampleData.cs
+++ b/source/OctoVersion.Tests/SampleData.cs
@@ -1,0 +1,45 @@
+using System;
+using OctoVersion.Core.VersionNumberCalculation;
+
+namespace OctoVersion.Tests;
+
+public class SampleData
+{
+    public SampleData(
+        string[]? nonPreReleaseTags,
+        string? nonPreReleaseTagsRegex,
+        int? overriddenMajorVersion,
+        int? overriddenMinorVersion,
+        int? overriddenPatchVersion,
+        string?currentBranch,
+        string? currentSha,
+        string? overriddenBuildMetadata,
+        SimpleVersion? version,
+        string? expectedInformationalVersion,
+        string? expectedFullSemVer)
+    {
+        NonPreReleaseTags = nonPreReleaseTags ?? throw new ArgumentNullException(nameof(nonPreReleaseTags));
+        NonPreReleaseTagsRegex = nonPreReleaseTagsRegex ?? throw new ArgumentNullException(nameof(nonPreReleaseTagsRegex));
+        OverriddenMajorVersion = overriddenMajorVersion;
+        OverriddenMinorVersion = overriddenMinorVersion;
+        OverriddenPatchVersion = overriddenPatchVersion;
+        CurrentBranch = currentBranch ?? throw new ArgumentNullException(nameof(currentBranch));
+        CurrentSha = currentSha ?? throw new ArgumentNullException(nameof(currentSha));
+        OverriddenBuildMetadata = overriddenBuildMetadata ?? throw new ArgumentNullException(nameof(overriddenBuildMetadata));
+        Version = version ?? throw new ArgumentNullException(nameof(version));
+        ExpectedInformationalVersion = expectedInformationalVersion ?? throw new ArgumentNullException(nameof(expectedInformationalVersion));
+        ExpectedFullSemVer = expectedFullSemVer ?? throw new ArgumentNullException(nameof(expectedFullSemVer));
+    }
+        
+    public string[] NonPreReleaseTags { get; }
+    public string NonPreReleaseTagsRegex { get; }
+    public int? OverriddenMajorVersion { get; }
+    public int? OverriddenMinorVersion { get; }
+    public int? OverriddenPatchVersion { get; }
+    public string CurrentBranch { get; }
+    public string CurrentSha { get; }
+    public string OverriddenBuildMetadata { get; }
+    public string ExpectedInformationalVersion { get; }
+    public string ExpectedFullSemVer { get; }
+    public SimpleVersion Version { get; }
+}

--- a/source/OctoVersion.Tests/SampleData.cs
+++ b/source/OctoVersion.Tests/SampleData.cs
@@ -25,7 +25,7 @@ public class SampleData
         OverriddenPatchVersion = overriddenPatchVersion;
         CurrentBranch = currentBranch ?? throw new ArgumentNullException(nameof(currentBranch));
         CurrentSha = currentSha ?? throw new ArgumentNullException(nameof(currentSha));
-        OverriddenBuildMetadata = overriddenBuildMetadata ?? throw new ArgumentNullException(nameof(overriddenBuildMetadata));
+        OverriddenBuildMetadata = overriddenBuildMetadata;
         Version = version ?? throw new ArgumentNullException(nameof(version));
         ExpectedInformationalVersion = expectedInformationalVersion ?? throw new ArgumentNullException(nameof(expectedInformationalVersion));
         ExpectedFullSemVer = expectedFullSemVer ?? throw new ArgumentNullException(nameof(expectedFullSemVer));
@@ -38,7 +38,7 @@ public class SampleData
     public int? OverriddenPatchVersion { get; }
     public string CurrentBranch { get; }
     public string CurrentSha { get; }
-    public string OverriddenBuildMetadata { get; }
+    public string? OverriddenBuildMetadata { get; }
     public string ExpectedInformationalVersion { get; }
     public string ExpectedFullSemVer { get; }
     public SimpleVersion Version { get; }

--- a/source/OctoVersion.Tests/SampleDataBuilder.cs
+++ b/source/OctoVersion.Tests/SampleDataBuilder.cs
@@ -1,0 +1,107 @@
+using System;
+using OctoVersion.Core.VersionNumberCalculation;
+
+namespace OctoVersion.Tests;
+
+public class SampleDataBuilder
+{
+    string[]? nonPreReleaseTags;
+    string? nonPreReleaseTagsRegex;
+    int? overriddenMajorVersion;
+    int? overriddenMinorVersion;
+    int? overriddenPatchVersion;
+    string? currentBranch;
+    string? currentSha;
+    string? overriddenBuildMetadata;
+    SimpleVersion? version;
+    string? expectedInformationalVersion;
+    string? expectedFullSemVer;
+
+    public SampleDataBuilder WithNonPreReleaseTags(string[] tags)
+    {
+        this.nonPreReleaseTags = tags;
+        return this;
+    }
+
+    public SampleDataBuilder WithNonPreReleaseTagsRegex(string regex)
+    {
+        this.nonPreReleaseTagsRegex = regex;
+        return this;
+    }
+
+    public SampleDataBuilder WithOverriddenMajorVersion(int? majorVersion)
+    {
+        this.overriddenMajorVersion = majorVersion;
+        return this;
+    }
+
+    public SampleDataBuilder WithOverriddenMinorVersion(int? minorVersion)
+    {
+        this.overriddenMinorVersion = minorVersion;
+        return this;
+    }
+
+    public SampleDataBuilder WithOverriddenPatchVersion(int? patchVersion)
+    {
+        this.overriddenPatchVersion = patchVersion;
+        return this;
+    }
+
+    public SampleDataBuilder WithCurrentBranch(string branch)
+    {
+        this.currentBranch = branch;
+        return this;
+    }
+
+    public SampleDataBuilder WithCurrentSha(string sha)
+    {
+        this.currentSha = sha;
+        return this;
+    }
+
+    public SampleDataBuilder WithOverriddenBuildMetadata(string? buildMetadata)
+    {
+        this.overriddenBuildMetadata = buildMetadata;
+        return this;
+    }
+
+    public SampleDataBuilder WithVersion(SimpleVersion newVersion)
+    {
+        this.version = newVersion;
+        return this;
+    }
+
+    public SampleDataBuilder WithExpectedInformationalVersion(string expected)
+    {
+        this.expectedInformationalVersion = expected;
+        return this;
+    }
+        
+    public SampleDataBuilder ExpectAnInformationalVersionOf(string expected)
+    {
+        this.expectedInformationalVersion = expected;
+        return this;
+    }
+
+    public SampleDataBuilder ExpectAFullSemVerOf(string expected)
+    {
+        this.expectedFullSemVer = expected;
+        return this;
+    }
+
+    public SampleData Build()
+    {
+        return new SampleData(
+            nonPreReleaseTags,
+            nonPreReleaseTagsRegex,
+            overriddenMajorVersion,
+            overriddenMinorVersion,
+            overriddenPatchVersion,
+            currentBranch,
+            currentSha,
+            overriddenBuildMetadata,
+            version,
+            expectedInformationalVersion,
+            expectedFullSemVer);
+    }
+}

--- a/source/OctoVersion.Tests/StructuredOutputFactoryFixture.cs
+++ b/source/OctoVersion.Tests/StructuredOutputFactoryFixture.cs
@@ -35,146 +35,73 @@ namespace OctoVersion.Tests
 
         static IEnumerable<SampleData> TestCases()
         {
-            SampleData ForDefaultScenario()
+            SampleDataBuilder ForDefaultScenario()
             {
-                return new SampleData
-                {
-                    NonPreReleaseTags = new[] { "refs/heads/main" },
-                    NonPreReleaseTagsRegex = string.Empty,
-                    OverriddenMajorVersion = null,
-                    OverriddenMinorVersion = null,
-                    OverriddenPatchVersion = null,
-                    CurrentBranch = "refs/heads/main",
-                    CurrentSha = "a1b2c3d4e5",
-                    OverriddenBuildMetadata = null,
-                    Version = new SimpleVersion(1, 2, 3),
-                    ExpectedInformationalVersion = "1.2.3+Branch.main.Sha.a1b2c3d4e5"
-                };
+                return new SampleDataBuilder()
+                    .WithNonPreReleaseTags(new[] { "refs/heads/main" })
+                    .WithNonPreReleaseTagsRegex(string.Empty)
+                    .WithOverriddenMajorVersion(null)
+                    .WithOverriddenMinorVersion(null)
+                    .WithOverriddenPatchVersion(null)
+                    .WithCurrentBranch("refs/heads/main")
+                    .WithCurrentSha("a1b2c3d4e5")
+                    .WithOverriddenBuildMetadata(null)
+                    .WithVersion(new SimpleVersion(1, 2, 3))
+                    .WithExpectedInformationalVersion("1.2.3+Branch.main.Sha.a1b2c3d4e5");
             }
 
             yield return ForDefaultScenario()
                 .ExpectAnInformationalVersionOf("1.2.3+Branch.main.Sha.a1b2c3d4e5")
-                .ExpectAFullSemVerOf("1.2.3");
+                .ExpectAFullSemVerOf("1.2.3")
+                .Build();
             yield return ForDefaultScenario()
                 .WithOverriddenMajorVersion(9)
                 .ExpectAnInformationalVersionOf("9.2.3+Branch.main.Sha.a1b2c3d4e5")
-                .ExpectAFullSemVerOf("9.2.3");
+                .ExpectAFullSemVerOf("9.2.3")
+                .Build();
             yield return ForDefaultScenario()
                 .WithOverriddenMinorVersion(9)
                 .ExpectAnInformationalVersionOf("1.9.3+Branch.main.Sha.a1b2c3d4e5")
-                .ExpectAFullSemVerOf("1.9.3");
+                .ExpectAFullSemVerOf("1.9.3")
+                .Build();
             yield return ForDefaultScenario()
                 .WithOverriddenPatchVersion(9)
                 .ExpectAnInformationalVersionOf("1.2.9+Branch.main.Sha.a1b2c3d4e5")
-                .ExpectAFullSemVerOf("1.2.9");
+                .ExpectAFullSemVerOf("1.2.9")
+                .Build();
             yield return ForDefaultScenario()
                 .WithOverriddenBuildMetadata("custom build meta/data")
                 .ExpectAnInformationalVersionOf("1.2.3+custom-build-meta-data")
-                .ExpectAFullSemVerOf("1.2.3");
+                .ExpectAFullSemVerOf("1.2.3")
+                .Build();
             yield return ForDefaultScenario()
                 .WithCurrentSha("aaabbbccc")
                 .ExpectAnInformationalVersionOf("1.2.3+Branch.main.Sha.aaabbbccc")
-                .ExpectAFullSemVerOf("1.2.3");
+                .ExpectAFullSemVerOf("1.2.3")
+                .Build();
             yield return ForDefaultScenario()
                 .WithVersion(new SimpleVersion(9, 8, 7))
                 .ExpectAnInformationalVersionOf("9.8.7+Branch.main.Sha.a1b2c3d4e5")
-                .ExpectAFullSemVerOf("9.8.7");
+                .ExpectAFullSemVerOf("9.8.7")
+                .Build();
             yield return ForDefaultScenario()
                 .WithNonPreReleaseTags(new[] { "refs/heads/trunk" })
                 .ExpectAnInformationalVersionOf("1.2.3-main+Branch.main.Sha.a1b2c3d4e5")
-                .ExpectAFullSemVerOf("1.2.3-main");
+                .ExpectAFullSemVerOf("1.2.3-main")
+                .Build();
             yield return ForDefaultScenario()
-                .WithNonPreReleaseTags(new string[0])
+                .WithNonPreReleaseTags(Array.Empty<string>())
                 .WithNonPreReleaseTagsRegex("refs/heads/m.*")
                 .ExpectAnInformationalVersionOf("1.2.3+Branch.main.Sha.a1b2c3d4e5")
-                .ExpectAFullSemVerOf("1.2.3");
+                .ExpectAFullSemVerOf("1.2.3")
+                .Build();
             yield return ForDefaultScenario()
-                .WithNonPreReleaseTags(new string[0])
+                .WithNonPreReleaseTags(Array.Empty<string>())
                 .WithNonPreReleaseTagsRegex("refs/heads/m.*")
                 .WithCurrentBranch("refs/heads/feature/versioning")
                 .ExpectAnInformationalVersionOf("1.2.3-feature-versioning+Branch.feature-versioning.Sha.a1b2c3d4e5")
-                .ExpectAFullSemVerOf("1.2.3-feature-versioning");
-        }
-    }
-
-    public class SampleData
-    {
-        public string[] NonPreReleaseTags { get; set; }
-        public string NonPreReleaseTagsRegex { get; set; }
-        public int? OverriddenMajorVersion { get; set; }
-        public int? OverriddenMinorVersion { get; set; }
-        public int? OverriddenPatchVersion { get; set; }
-        public string CurrentBranch { get; set; }
-        public string CurrentSha { get; set; }
-        public string OverriddenBuildMetadata { get; set; }
-        public string ExpectedInformationalVersion { get; set; }
-        public string ExpectedFullSemVer { get; set; }
-        public SimpleVersion Version { get; set; }
-
-        public SampleData WithNonPreReleaseTags(string[] nonPreReleaseTags)
-        {
-            NonPreReleaseTags = nonPreReleaseTags;
-            return this;
-        }
-
-        public SampleData WithNonPreReleaseTagsRegex(string nonPreReleaseTagsRegex)
-        {
-            NonPreReleaseTagsRegex = nonPreReleaseTagsRegex;
-            return this;
-        }
-
-        public SampleData WithOverriddenMajorVersion(int? overriddenMajorVersion)
-        {
-            OverriddenMajorVersion = overriddenMajorVersion;
-            return this;
-        }
-
-        public SampleData WithOverriddenMinorVersion(int? overriddenMinorVersion)
-        {
-            OverriddenMinorVersion = overriddenMinorVersion;
-            return this;
-        }
-
-        public SampleData WithOverriddenPatchVersion(int? overriddenPatchVersion)
-        {
-            OverriddenPatchVersion = overriddenPatchVersion;
-            return this;
-        }
-
-        public SampleData WithCurrentBranch(string currentBranch)
-        {
-            CurrentBranch = currentBranch;
-            return this;
-        }
-
-        public SampleData WithCurrentSha(string currentSha)
-        {
-            CurrentSha = currentSha;
-            return this;
-        }
-
-        public SampleData WithOverriddenBuildMetadata(string overriddenBuildMetadata)
-        {
-            OverriddenBuildMetadata = overriddenBuildMetadata;
-            return this;
-        }
-
-        public SampleData WithVersion(SimpleVersion version)
-        {
-            Version = version;
-            return this;
-        }
-
-        public SampleData ExpectAnInformationalVersionOf(string expected)
-        {
-            ExpectedInformationalVersion = expected;
-            return this;
-        }
-
-        public SampleData ExpectAFullSemVerOf(string expected)
-        {
-            ExpectedFullSemVer = expected;
-            return this;
+                .ExpectAFullSemVerOf("1.2.3-feature-versioning")
+                .Build();
         }
     }
 }

--- a/source/OctoVersion.Tests/WhenParsingASemanticVersion.cs
+++ b/source/OctoVersion.Tests/WhenParsingASemanticVersion.cs
@@ -23,12 +23,12 @@ namespace OctoVersion.Tests
 
         public static IEnumerable<object[]> TestCases()
         {
-            yield return new object[] { "", null };
-            yield return new object[] { "spit.spot", null };
-            yield return new object[] { "1.2.x", null };
-            yield return new object[] { "1.x.3", null };
-            yield return new object[] { "x.2.3", null };
-            yield return new object[] { "1..2", null };
+            yield return new object[] { "", null! };
+            yield return new object[] { "spit.spot", null! };
+            yield return new object[] { "1.2.x", null! };
+            yield return new object[] { "1.x.3", null! };
+            yield return new object[] { "x.2.3", null! };
+            yield return new object[] { "1..2", null! };
             yield return new object[]
             {
                 "0.0.0", new SemanticVersion(0,

--- a/source/OctoVersion.Tests/WhenParsingASimpleVersion.cs
+++ b/source/OctoVersion.Tests/WhenParsingASimpleVersion.cs
@@ -23,12 +23,12 @@ namespace OctoVersion.Tests
             yield return new object[] { "1", new SimpleVersion(1, 0, 0) };
             yield return new object[] { "1.2", new SimpleVersion(1, 2, 0) };
             yield return new object[] { "1.2.3", new SimpleVersion(1, 2, 3) };
-            yield return new object[] { "1.2.3-alpha", null };
+            yield return new object[] { "1.2.3-alpha", null! };
             yield return new object[] { "1+some-build-info", new SimpleVersion(1, 0, 0) };
             yield return new object[] { "1.2+some-build-info", new SimpleVersion(1, 2, 0) };
             yield return new object[] { "1.2.3+some-build-info", new SimpleVersion(1, 2, 3) };
             yield return new object[] { "v0.1.0", new SimpleVersion(0, 1, 0) };
-            yield return new object[] { "x0.1.0", null };
+            yield return new object[] { "x0.1.0", null! };
         }
     }
 }


### PR DESCRIPTION
This PR fixes all remaining code warnings:

* it enables `TreatWarningsAsErrors`, to prevent any backsliding
* it ignores the warning `NU5104` as we need to rely on a pre-release version of gitlib2sharp
* It converts the `SampleData` class to a builder to allow us to be sure about nulls