### PR TITLE
Update nuke to 6.0.3

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -2,10 +2,10 @@
   "version": 1,
   "isRoot": true,
   "tools": {
-    "cake.tool": {
-      "version": "0.38.5",
+    "nuke.globaltool": {
+      "version": "6.0.3",
       "commands": [
-        "dotnet-cake"
+        "nuke"
       ]
     }
   }

--- a/build.cmd
+++ b/build.cmd
@@ -4,4 +4,4 @@
 :; exit $?
 
 @ECHO OFF
-powershell -ExecutionPolicy ByPass -NoProfile "%~dp0build.ps1" %*
+powershell -ExecutionPolicy ByPass -NoProfile -File "%~dp0build.ps1" %*

--- a/build.ps1
+++ b/build.ps1
@@ -56,14 +56,14 @@ else {
     # Install by channel or version
     $DotNetDirectory = "$TempDirectory\dotnet-win"
     if (!(Test-Path variable:DotNetVersion)) {
-        ExecSafe { & $DotNetInstallFile -InstallDir $DotNetDirectory -Channel $DotNetChannel -NoPath }
+        ExecSafe { & powershell $DotNetInstallFile -InstallDir $DotNetDirectory -Channel $DotNetChannel -NoPath }
     } else {
-        ExecSafe { & $DotNetInstallFile -InstallDir $DotNetDirectory -Version $DotNetVersion -NoPath }
+        ExecSafe { & powershell $DotNetInstallFile -InstallDir $DotNetDirectory -Version $DotNetVersion -NoPath }
     }
     $env:DOTNET_EXE = "$DotNetDirectory\dotnet.exe"
 }
 
-Write-Output "Microsoft (R) .NET Core SDK version $(& $env:DOTNET_EXE --version)"
+Write-Output "Microsoft (R) .NET SDK version $(& $env:DOTNET_EXE --version)"
 
 ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }
 ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,7 @@ else
     export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
 fi
 
-echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
+echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
 
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
 "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -30,7 +30,7 @@ class Build : NukeBuild
     [Parameter("Branch name for OctoVersion to use to calculate the version number. Can be set via the environment variable " + CiBranchNameEnvVariable + ".", Name = CiBranchNameEnvVariable)]
     string BranchName { get; set; }
 
-    [OctoVersion(BranchParameter = nameof(BranchName), AutoDetectBranchParameter = nameof(AutoDetectBranch))] 
+    [OctoVersion(BranchParameter = nameof(BranchName), AutoDetectBranchParameter = nameof(AutoDetectBranch), Framework = "net6.0")] 
     public OctoVersionInfo OctoVersionInfo;
 
     AbsolutePath SourceDirectory => RootDirectory / "source";

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -7,14 +7,15 @@
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
     <NukeScriptDirectory>..</NukeScriptDirectory>
+    <NukeTelemetryVersion>1</NukeTelemetryVersion>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="6.0.1" />
+    <PackageReference Include="Nuke.Common" Version="6.0.3" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageDownload Include="NuGet.CommandLine" Version="[5.8.1]" />
-    <PackageDownload Include="OctoVersion.Tool" Version="[0.2.951]" />
+    <PackageDownload Include="OctoVersion.Tool" Version="[0.3.11]" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updates nuke to `6.0.3`.

As part of that:
* it removes the dotnet tool `cake.tool` and replaces it with `nuke.globaltool`
* `nuke :update` fixed up a bunch of the build scripts
* tells the nuke `OctoVersion` attribute to use `net6.0`
* updates the `OctoVersion.Tool` version to use one that works on M1 Macs