### PR TITLE
Update langversion to fix prettybot build

### DIFF
--- a/source/Cake.OctoVersion/Cake.OctoVersion.csproj
+++ b/source/Cake.OctoVersion/Cake.OctoVersion.csproj
@@ -5,6 +5,7 @@
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Version>0.0.0</Version>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<LangVersion>11</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/source/Cake.OctoVersion/Cake.OctoVersion.csproj
+++ b/source/Cake.OctoVersion/Cake.OctoVersion.csproj
@@ -5,7 +5,7 @@
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Version>0.0.0</Version>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-		<LangVersion>11</LangVersion>
+		<LangVersion>10</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/source/OctoVersion.Core/OctoVersion.Core.csproj
+++ b/source/OctoVersion.Core/OctoVersion.Core.csproj
@@ -9,6 +9,7 @@
 		<PackageId>Octopus.OctoVersion.Core</PackageId>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<NoWarn>1701;1702;NU5104</NoWarn>
+		<LangVersion>11</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/source/OctoVersion.Core/OctoVersion.Core.csproj
+++ b/source/OctoVersion.Core/OctoVersion.Core.csproj
@@ -9,7 +9,7 @@
 		<PackageId>Octopus.OctoVersion.Core</PackageId>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<NoWarn>1701;1702;NU5104</NoWarn>
-		<LangVersion>11</LangVersion>
+		<LangVersion>10</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/source/OctoVersion.Tests/OctoVersion.Tests.csproj
+++ b/source/OctoVersion.Tests/OctoVersion.Tests.csproj
@@ -6,6 +6,7 @@
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/OctoVersion.Tests/OctoVersion.Tests.csproj
+++ b/source/OctoVersion.Tests/OctoVersion.Tests.csproj
@@ -6,7 +6,7 @@
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>11</LangVersion>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/OctoVersion.Tool/OctoVersion.Tool.csproj
+++ b/source/OctoVersion.Tool/OctoVersion.Tool.csproj
@@ -16,7 +16,7 @@
 		<Authors>Octopus Deploy Pty. Ltd.</Authors>
 		<PackageProjectUrl>https://github.com/OctopusDeploy/OctoVersion</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/OctopusDeploy/OctoVersion</RepositoryUrl>
-		<LangVersion>10</LangVersion>
+		<LangVersion>11</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/source/OctoVersion.Tool/OctoVersion.Tool.csproj
+++ b/source/OctoVersion.Tool/OctoVersion.Tool.csproj
@@ -16,7 +16,7 @@
 		<Authors>Octopus Deploy Pty. Ltd.</Authors>
 		<PackageProjectUrl>https://github.com/OctopusDeploy/OctoVersion</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/OctopusDeploy/OctoVersion</RepositoryUrl>
-		<LangVersion>11</LangVersion>
+		<LangVersion>10</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
We're getting [failed builds](https://build.octopushq.com/buildConfiguration/OctopusDeploy_LIbraries_OctoVersion_Ci/5324418?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&expandBuildProblemsSection=true&showLog=5324418_1067_837.1063&logView=flowAware):

>     /opt/buildagent/work/fe69bdc7275df075/source/Cake.OctoVersion/CakeExtensions.cs(11,1): error CS8400: Feature 'file-scoped namespace' is not available in C# 8.0. Please use language version 10.0 or greater. [/opt/buildagent/work/fe69bdc7275df075/source/Cake.OctoVersion/Cake.OctoVersion.csproj]
