### PR TITLE
Added net7 as a framework for the tool

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -33,6 +33,7 @@
             "AppVeyor",
             "AzurePipelines",
             "Bamboo",
+            "Bitbucket",
             "Bitrise",
             "GitHubActions",
             "GitLab",

--- a/build/ci-environment.dockerfile
+++ b/build/ci-environment.dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/dotnet/sdk:7.0
+
+RUN export DEBIAN_FRONTEND=noninteractive
+
+# Setup the Microsoft package feed
+RUN wget https://packages.microsoft.com/config/debian/11/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+RUN dpkg -i packages-microsoft-prod.deb
+RUN rm packages-microsoft-prod.deb
+    
+# install .NET 6 SDK
+RUN apt-get update && apt-get install -y dotnet-sdk-6.0
+
+RUN dotnet tool install Nuke.GlobalTool --global

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.101",
+    "version": "7.0.0",
     "rollForward": "latestFeature"
   }
 }

--- a/source/OctoVersion.Tool/OctoVersion.Tool.csproj
+++ b/source/OctoVersion.Tool/OctoVersion.Tool.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 		<PackAsTool>true</PackAsTool>
 		<ToolCommandName>octoversion</ToolCommandName>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
The default .NET SDK containers only have a single framework on them, so when building things with .NET 7 you get an error as this tool is still .NET 6 and no runtime is installed. This bundles both versions in the Tool package