### PR TITLE
Update to latest OctoVersion.Tool

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -17,6 +17,6 @@
 
   <ItemGroup>
     <PackageDownload Include="NuGet.CommandLine" Version="[5.8.1]" />
-    <PackageDownload Include="OctoVersion.Tool" Version="[0.3.164]" />
+    <PackageDownload Include="Octopus.OctoVersion.Tool" Version="[0.3.164]" />
   </ItemGroup>
 </Project>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -17,6 +17,6 @@
 
   <ItemGroup>
     <PackageDownload Include="NuGet.CommandLine" Version="[5.8.1]" />
-    <PackageDownload Include="OctoVersion.Tool" Version="[0.3.11]" />
+    <PackageDownload Include="OctoVersion.Tool" Version="[0.3.164]" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
We want to use the latest version (to get the latest OctoVersion fixes), but because of the way the PackageDownload references require a specific version, dependabot doesn't auto-update them.

Note: this project builds in TeamCity, rather than GitHub Actions, so the fixes aren't strictly required, it's more "just in case" we want to switch to GHA at some point.

**Update**: :sadpanda: We cant do this yet, as we're waiting on https://github.com/nuke-build/nuke/pull/1104 being released in Nuke. We'll need to update that at the same time.
I've reached out to the author of Nuke to get an update.