### PR TITLE
Upgrade to net7

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -44,7 +44,7 @@ $DOTNET_EXE --list-sdks
 
 echo "Running with .NET SDK version $("$DOTNET_EXE" --version)"
 
-echo "Building $project"
+echo "Building $BUILD_PROJECT_FILE"
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
 
 echo "Running $project"

--- a/build.sh
+++ b/build.sh
@@ -41,7 +41,7 @@ echo "Installing net7"
 echo "Installed net7"
 export DOTNET_EXE="$TEMP_DIRECTORY/dotnet/dotnet"
 
-DOTNET_EXE --list-sdks
+$DOTNET_EXE --list-sdks
 
 echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
 

--- a/build.sh
+++ b/build.sh
@@ -34,18 +34,20 @@ chmod +x "$DOTNET_INSTALL_FILE"
 
 echo "Installing net6"
 "$DOTNET_INSTALL_FILE" --install-dir "$TEMP_DIRECTORY/dotnet" --channel "6.0" --no-path
-echo "Installed net6"
 
 echo "Installing net7"
 "$DOTNET_INSTALL_FILE" --install-dir "$TEMP_DIRECTORY/dotnet" --channel "7.0" --no-path
-echo "Installed net7"
 export DOTNET_EXE="$TEMP_DIRECTORY/dotnet/dotnet"
 
+echo "Installing .NET SDK versions:"
 $DOTNET_EXE --list-sdks
 
-echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
+echo "Running with .NET SDK version $("$DOTNET_EXE" --version)"
 
+echo "Building $project"
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
+
+echo "Running $project"
 "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"
 
 exit $?

--- a/build.sh
+++ b/build.sh
@@ -10,9 +10,9 @@ SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 ###########################################################################
 
 BUILD_PROJECT_FILE="$SCRIPT_DIR/build/_build.csproj"
-TEMP_DIRECTORY="$SCRIPT_DIR//.nuke/temp"
+TEMP_DIRECTORY="$SCRIPT_DIR/.nuke/temp"
 
-DOTNET_GLOBAL_FILE="$SCRIPT_DIR//global.json"
+DOTNET_GLOBAL_FILE="$SCRIPT_DIR/global.json"
 DOTNET_INSTALL_URL="https://dot.net/v1/dotnet-install.sh"
 DOTNET_CHANNEL="Current"
 
@@ -32,30 +32,13 @@ mkdir -p "$TEMP_DIRECTORY"
 curl -Lsfo "$DOTNET_INSTALL_FILE" "$DOTNET_INSTALL_URL"
 chmod +x "$DOTNET_INSTALL_FILE"
 
-# check if we've got the versions we expect
-has_net_6=false
-has_net_7=false
-for sdk_version in $(dotnet --list-sdks | awk '{print $1}'); do
-    if [[ "$sdk_version" == 6.* ]]; then
-        echo "Found net6"
-        has_net_6=true
-    elif [[ "$sdk_version" == 7.* ]]; then
-        echo "Found net7"
-        has_net_7=true
-    fi
-done
+echo "Installing net6"
+"$DOTNET_INSTALL_FILE" --install-dir "$TEMP_DIRECTORY/dotnet" --channel "6.0" --no-path
+echo "Installed net6"
 
-if ! $has_net_6; then
-    echo "Installing net6"
-    "$DOTNET_INSTALL_FILE" --install-dir "$TEMP_DIRECTORY/net6" --channel "6.0" --no-path
-    echo "Installed net6"
-fi
-if ! $has_net_7; then
-    echo "Installing net7"
-    "$DOTNET_INSTALL_FILE" --install-dir "$TEMP_DIRECTORY/net7" --channel "7.0" --no-path
-    echo "Installed net7"
-fi
-
+echo "Installing net7"
+"$DOTNET_INSTALL_FILE" --install-dir "$TEMP_DIRECTORY/dotnet" --channel "7.0" --no-path
+echo "Installed net7"
 export DOTNET_EXE="$TEMP_DIRECTORY/dotnet"
 
 echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"

--- a/build.sh
+++ b/build.sh
@@ -20,6 +20,48 @@ export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_MULTILEVEL_LOOKUP=0
 
+#### START CUSTOM CODE ####
+# This file is an odd one. `nuke :update` wants to make edits to it, so we want to keep it similar to the default 
+# as we can. But, we want to do some tricky stuff, and make sure both dotnet 6 and dotnet 7 are installed, so we
+# can compile for both versions. So... We've got our "custom code" block here, which we want to keep, and the 
+# default code down below so we can see what changes are made upstream, and apply them to ours if we need to.
+
+# Download install script
+DOTNET_INSTALL_FILE="$TEMP_DIRECTORY/dotnet-install.sh"
+mkdir -p "$TEMP_DIRECTORY"
+curl -Lsfo "$DOTNET_INSTALL_FILE" "$DOTNET_INSTALL_URL"
+chmod +x "$DOTNET_INSTALL_FILE"
+
+# check if we've got the versions we expect
+has_net_6=false
+has_net_7=false
+for sdk_version in $(dotnet --list-sdks | awk '{print $1}'); do
+    if [[ "$sdk_version" == 6.* ]]; then
+        has_net_6=true
+    elif [[ "$sdk_version" == 7.* ]]; then
+        has_net_7=true
+    fi
+done
+
+if ! has_net_6; then
+    "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --version "6.0" --no-path
+fi
+if ! has_net_7; then
+    "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --version "7.0" --no-path
+fi
+
+export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
+
+echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
+
+"$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
+"$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"
+
+exit $?
+
+##### END CUSTOM CODE #####
+
+
 ###########################################################################
 # EXECUTION
 ###########################################################################

--- a/build.sh
+++ b/build.sh
@@ -47,12 +47,12 @@ done
 
 if ! $has_net_6; then
     echo "Installing net6"
-    "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --version "6.0" --no-path
+    "$DOTNET_INSTALL_FILE" --install-dir "$TEMP_DIRECTORY/net6" --version "6.0" --no-path
     echo "Installed net6"
 fi
 if ! $has_net_7; then
     echo "Installing net7"
-    "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --version "7.0" --no-path
+    "$DOTNET_INSTALL_FILE" --install-dir "$TEMP_DIRECTORY/net7" --version "7.0" --no-path
     echo "Installed net7"
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -37,17 +37,23 @@ has_net_6=false
 has_net_7=false
 for sdk_version in $(dotnet --list-sdks | awk '{print $1}'); do
     if [[ "$sdk_version" == 6.* ]]; then
+        echo "Found net6"
         has_net_6=true
     elif [[ "$sdk_version" == 7.* ]]; then
+        echo "Found net7"
         has_net_7=true
     fi
 done
 
 if ! $has_net_6; then
+    echo "Installing net6"
     "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --version "6.0" --no-path
+    echo "Installed net6"
 fi
 if ! $has_net_7; then
+    echo "Installing net7"
     "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --version "7.0" --no-path
+    echo "Installed net7"
 fi
 
 export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"

--- a/build.sh
+++ b/build.sh
@@ -10,50 +10,15 @@ SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 ###########################################################################
 
 BUILD_PROJECT_FILE="$SCRIPT_DIR/build/_build.csproj"
-TEMP_DIRECTORY="$SCRIPT_DIR/.nuke/temp"
+TEMP_DIRECTORY="$SCRIPT_DIR//.nuke/temp"
 
-DOTNET_GLOBAL_FILE="$SCRIPT_DIR/global.json"
+DOTNET_GLOBAL_FILE="$SCRIPT_DIR//global.json"
 DOTNET_INSTALL_URL="https://dot.net/v1/dotnet-install.sh"
 DOTNET_CHANNEL="Current"
 
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 export DOTNET_MULTILEVEL_LOOKUP=0
-
-#### START CUSTOM CODE ####
-# This file is an odd one. `nuke :update` wants to make edits to it, so we want to keep it similar to the default 
-# as we can. But, we want to do some tricky stuff, and make sure both dotnet 6 and dotnet 7 are installed, so we
-# can compile for both versions. So... We've got our "custom code" block here, which we want to keep, and the 
-# default code down below so we can see what changes are made upstream, and apply them to ours if we need to.
-
-# Download install script
-DOTNET_INSTALL_FILE="$TEMP_DIRECTORY/dotnet-install.sh"
-mkdir -p "$TEMP_DIRECTORY"
-curl -Lsfo "$DOTNET_INSTALL_FILE" "$DOTNET_INSTALL_URL"
-chmod +x "$DOTNET_INSTALL_FILE"
-
-echo "Installing net6"
-"$DOTNET_INSTALL_FILE" --install-dir "$TEMP_DIRECTORY/dotnet" --channel "6.0" --no-path
-
-echo "Installing net7"
-"$DOTNET_INSTALL_FILE" --install-dir "$TEMP_DIRECTORY/dotnet" --channel "7.0" --no-path
-export DOTNET_EXE="$TEMP_DIRECTORY/dotnet/dotnet"
-
-echo "Installing .NET SDK versions:"
-$DOTNET_EXE --list-sdks
-
-echo "Running with .NET SDK version $("$DOTNET_EXE" --version)"
-
-echo "Building $BUILD_PROJECT_FILE"
-"$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
-
-echo "Running $project"
-"$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"
-
-exit $?
-
-##### END CUSTOM CODE #####
-
 
 ###########################################################################
 # EXECUTION

--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,7 @@ if ! $has_net_7; then
     echo "Installed net7"
 fi
 
-export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
+export DOTNET_EXE="$TEMP_DIRECTORY/dotnet"
 
 echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
 

--- a/build.sh
+++ b/build.sh
@@ -47,12 +47,12 @@ done
 
 if ! $has_net_6; then
     echo "Installing net6"
-    "$DOTNET_INSTALL_FILE" --install-dir "$TEMP_DIRECTORY/net6" --version "6.0" --no-path
+    "$DOTNET_INSTALL_FILE" --install-dir "$TEMP_DIRECTORY/net6" --channel "6.0" --no-path
     echo "Installed net6"
 fi
 if ! $has_net_7; then
     echo "Installing net7"
-    "$DOTNET_INSTALL_FILE" --install-dir "$TEMP_DIRECTORY/net7" --version "7.0" --no-path
+    "$DOTNET_INSTALL_FILE" --install-dir "$TEMP_DIRECTORY/net7" --channel "7.0" --no-path
     echo "Installed net7"
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -43,10 +43,10 @@ for sdk_version in $(dotnet --list-sdks | awk '{print $1}'); do
     fi
 done
 
-if ! has_net_6; then
+if ! $has_net_6; then
     "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --version "6.0" --no-path
 fi
-if ! has_net_7; then
+if ! $has_net_7; then
     "$DOTNET_INSTALL_FILE" --install-dir "$DOTNET_DIRECTORY" --version "7.0" --no-path
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,9 @@ echo "Installed net6"
 echo "Installing net7"
 "$DOTNET_INSTALL_FILE" --install-dir "$TEMP_DIRECTORY/dotnet" --channel "7.0" --no-path
 echo "Installed net7"
-export DOTNET_EXE="$TEMP_DIRECTORY/dotnet"
+export DOTNET_EXE="$TEMP_DIRECTORY/dotnet/dotnet"
+
+DOTNET_EXE --list-sdks
 
 echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
 

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -40,9 +40,9 @@ class Build : NukeBuild
         .Before(Restore)
         .Executes(() =>
         {
-            SourceDirectory.GlobDirectories("**/bin", "**/obj", "**/TestResults").ForEach(DeleteDirectory);
-            EnsureCleanDirectory(ArtifactsDirectory);
-            EnsureCleanDirectory(LocalPackagesDirectory);
+            SourceDirectory.GlobDirectories("**/bin", "**/obj", "**/TestResults").ForEach(x => x.DeleteDirectory());
+            ArtifactsDirectory.CreateOrCleanDirectory();
+            LocalPackagesDirectory.CreateOrCleanDirectory();
         });
 
     Target Restore => _ => _
@@ -77,7 +77,7 @@ class Build : NukeBuild
                 .SetFilter(TestFilter)
                 .EnableNoBuild()
                 .EnableNoRestore());
-            GlobFiles(SourceDirectory, "**/*.trx").ForEach(x => CopyFileToDirectory(x, ArtifactsDirectory));
+            SourceDirectory.GlobFiles( "**/*.trx").ForEach(x => CopyFileToDirectory(x, ArtifactsDirectory));
         });
 
     Target Pack => _ => _
@@ -99,8 +99,8 @@ class Build : NukeBuild
         .TriggeredBy(Pack)
         .Executes(() =>
         {
-            EnsureExistingDirectory(LocalPackagesDirectory);
-            GlobFiles(ArtifactsDirectory, $"*.{OctoVersionInfo.FullSemVer}.nupkg").ForEach(x => CopyFileToDirectory(x, LocalPackagesDirectory));
+            LocalPackagesDirectory.CreateOrCleanDirectory();
+            ArtifactsDirectory.GlobFiles($"*.{OctoVersionInfo.FullSemVer}.nupkg").ForEach(x => CopyFileToDirectory(x, LocalPackagesDirectory));
         });
 
     /// Support plugins are available for:

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramewor>net7.0</TargetFramewor>
+    <TargetFramework>net7.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -12,11 +12,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="6.3.0" />
+    <PackageReference Include="Nuke.Common" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageDownload Include="NuGet.CommandLine" Version="[5.8.1]" />
-    <PackageDownload Include="OctoVersion.Tool" Version="[0.3.11]" />
+    <PackageDownload Include="Octopus.OctoVersion.Tool" Version="[0.3.169]" />
   </ItemGroup>
 </Project>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net7.0</TargetFrameworks>
+    <TargetFramewor>net7.0</TargetFramewor>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net7.0</TargetFrameworks>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.101",
+    "version": "7.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/source/OctoVersion.Core/OctoVersion.Core.csproj
+++ b/source/OctoVersion.Core/OctoVersion.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<Version>0.0.0</Version>

--- a/source/OctoVersion.Tests/OctoVersion.Tests.csproj
+++ b/source/OctoVersion.Tests/OctoVersion.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <LangVersion>10</LangVersion>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>

--- a/source/OctoVersion.Tool/OctoVersion.Tool.csproj
+++ b/source/OctoVersion.Tool/OctoVersion.Tool.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFrameworks>net6.0;net7.0</TargetFrameworks>
 		<PackAsTool>true</PackAsTool>
 		<ToolCommandName>octoversion</ToolCommandName>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/source/OctoVersion.sln
+++ b/source/OctoVersion.sln
@@ -18,6 +18,7 @@ ProjectSection(SolutionItems) = preProject
 	..\NuGet.Config = ..\NuGet.Config
 	..\octoversion.json = ..\octoversion.json
 	..\README.md = ..\README.md
+	..\global.json = ..\global.json
 EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "_build", "..\build\_build.csproj", "{3F53A37E-23D1-4202-8A99-17BAA6480321}"


### PR DESCRIPTION
Adds support for net7. 

It also updates nuke to version 7.0.0, and OctoVersion to the `Octopus.OctoVersion.Tool` one instead of the deprecated `OctoVersion.Tool`

I've decided to do it an interesting way, and:
1) build in the standard `mcr.microsoft.com/dotnet/sdk:6.0` container
2) update the `build.sh` to install both dotnet 6 and dotnet 7
3) change the build script to call `./build.sh` directly.

Happy for feedback.

This is a different to @droyad's PR #123, and keeps more of the code in the repo rather than in teamcity.