### PR TITLE
Include missing properties from base class

### DIFF
--- a/source/OctoVersion.Core/OctoVersionInfo.cs
+++ b/source/OctoVersion.Core/OctoVersionInfo.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
 using System.Text.RegularExpressions;
 
 namespace OctoVersion.Core;
@@ -44,5 +46,16 @@ public class OctoVersionInfo : SemanticVersion
     public override string ToString()
     {
         return FullSemVer;
+    }
+
+    internal IEnumerable<(string Name, string Value)> GetProperties()
+    {
+        var properties = GetType().GetProperties(BindingFlags.Public | BindingFlags.FlattenHierarchy | BindingFlags.Instance);
+        
+        foreach (var property in properties)
+        {
+            var value = property.GetValue(this)?.ToString() ?? string.Empty;
+            yield return (property.Name, value);
+        }
     }
 }

--- a/source/OctoVersion.Core/OutputFormatting/Environment/EnvironmentOutputFormatter.cs
+++ b/source/OctoVersion.Core/OutputFormatting/Environment/EnvironmentOutputFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
 using OctoVersion.Core.Configuration;
 using OctoVersion.Core.Logging;
@@ -19,18 +20,25 @@ public class EnvironmentOutputFormatter : IOutputFormatter
 
     public void Write(OctoVersionInfo octoVersionInfo)
     {
-        const string prefix = ConfigurationBootstrapper.EnvironmentVariablePrefix;
-
-        var properties = octoVersionInfo.GetType()
-            .GetProperties(BindingFlags.Public | BindingFlags.DeclaredOnly | BindingFlags.Instance);
-        foreach (var property in properties)
+        foreach (var line in GetPropertiesToWrite(octoVersionInfo))
         {
-            var key = $"{prefix}{property.Name}";
-            var value = property.GetValue(octoVersionInfo)?.ToString() ?? string.Empty;
-            var line = $"{key}={value}";
             System.Console.WriteLine(line);
         }
     }
+
+    internal static IEnumerable<string> GetPropertiesToWrite(OctoVersionInfo octoVersionInfo)
+    {
+        const string prefix = ConfigurationBootstrapper.EnvironmentVariablePrefix;
+
+        var properties = octoVersionInfo.GetProperties();
+        foreach (var property in properties)
+        {
+            var key = $"{prefix}{property.Name}";
+            var line = $"{key}={property.Value}";
+            yield return line;
+        }
+    }
+
 
     public bool MatchesRuntimeEnvironment()
     {

--- a/source/OctoVersion.Core/OutputFormatting/GitHubActions/GitHubActionsOutputFormatter.cs
+++ b/source/OctoVersion.Core/OutputFormatting/GitHubActions/GitHubActionsOutputFormatter.cs
@@ -37,8 +37,7 @@ public class GitHubActionsOutputFormatter : IOutputFormatter
 
     static void WriteOutputVariables(OctoVersionInfo octoVersionInfo)
     {
-        var properties = octoVersionInfo.GetType()
-            .GetProperties(BindingFlags.Public | BindingFlags.DeclaredOnly | BindingFlags.Instance);
+        var properties = octoVersionInfo.GetProperties();
 
         // https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter
         // The outgoing parameters must be written to a temporary file (identified by the $GITHUB_OUTPUT environment
@@ -52,8 +51,7 @@ public class GitHubActionsOutputFormatter : IOutputFormatter
             foreach (var property in properties)
             {
                 var configurationVariableKey = $"octoversion_{property.Name.ToLowerInvariant()}";
-                var value = property.GetValue(octoVersionInfo)?.ToString() ?? string.Empty;
-                streamWriter.WriteLine($"{configurationVariableKey}={value}");
+                streamWriter.WriteLine($"{configurationVariableKey}={property.Value}");
             }
         }
         else

--- a/source/OctoVersion.Core/OutputFormatting/TeamCity/TeamCityOutputFormatter.cs
+++ b/source/OctoVersion.Core/OutputFormatting/TeamCity/TeamCityOutputFormatter.cs
@@ -39,19 +39,16 @@ public class TeamCityOutputFormatter : IOutputFormatter
         // ##teamcity[setParameter name='ddd' value='fff']
 
         const string prefix = ConfigurationBootstrapper.EnvironmentVariablePrefix;
-        var properties = octoVersionInfo.GetType()
-            .GetProperties(BindingFlags.Public | BindingFlags.DeclaredOnly | BindingFlags.Instance);
+        var properties = octoVersionInfo.GetProperties();
         foreach (var property in properties)
         {
             var environmentVariableKey = $"env.{prefix}{property.Name}";
             var configurationVariableKey = $"OctoVersion.{property.Name}";
 
-            var value = property.GetValue(octoVersionInfo)?.ToString() ?? string.Empty;
-
-            var environmentVariableMessage = $"##teamcity[setParameter name='{environmentVariableKey}' value='{value}']";
+            var environmentVariableMessage = $"##teamcity[setParameter name='{environmentVariableKey}' value='{property.Value}']";
             System.Console.WriteLine(environmentVariableMessage);
 
-            var configurationVariableMessage = $"##teamcity[setParameter name='{configurationVariableKey}' value='{value}']";
+            var configurationVariableMessage = $"##teamcity[setParameter name='{configurationVariableKey}' value='{property.Value}']";
             System.Console.WriteLine(configurationVariableMessage);
         }
     }

--- a/source/OctoVersion.Core/Properties/AssemblyInfo.cs
+++ b/source/OctoVersion.Core/Properties/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: InternalsVisibleTo("OctoVersion.Tests")]

--- a/source/OctoVersion.Tests/EnvironmentOutputFormatterFixture.cs
+++ b/source/OctoVersion.Tests/EnvironmentOutputFormatterFixture.cs
@@ -1,0 +1,46 @@
+using System.Linq;
+using OctoVersion.Core.OutputFormatting.Environment;
+using OctoVersion.Core.VersionNumberCalculation;
+using Shouldly;
+using Xunit;
+
+namespace OctoVersion.Tests;
+
+public class EnvironmentOutputFormatterFixture
+{
+    /// <remarks>
+    /// Relates to https://github.com/OctopusDeploy/OctoVersion/issues/98.
+    /// </remarks>
+    [Fact]
+    public void ReadsPropertiesFromBothOctoVersionInfoAndBaseClass()
+    {
+        var sampleData = new SampleDataBuilder()
+            .WithNonPreReleaseTags(new[] { "refs/heads/main" })
+            .WithNonPreReleaseTagsRegex(string.Empty)
+            .WithCurrentBranch("refs/heads/main")
+            .WithCurrentSha("a1b2c3d4e5")
+            .WithVersion(new SimpleVersion(1, 2, 3))
+            .Build();
+        
+        var octoVersionInfo = sampleData.ToOctoVersion();
+        
+        var propertiesToWrite = EnvironmentOutputFormatter
+            .GetPropertiesToWrite(octoVersionInfo)
+            .OrderBy(x => x)
+            .ToArray();
+        
+        propertiesToWrite.ShouldBeEquivalentTo(new [] {
+            "OCTOVERSION_BuildMetadata=Branch.main.Sha.a1b2c3d4e5",
+            "OCTOVERSION_BuildMetadataWithPlus=+Branch.main.Sha.a1b2c3d4e5",
+            "OCTOVERSION_FullSemVer=1.2.3",
+            "OCTOVERSION_InformationalVersion=1.2.3+Branch.main.Sha.a1b2c3d4e5",
+            "OCTOVERSION_Major=1",
+            "OCTOVERSION_MajorMinorPatch=1.2.3",
+            "OCTOVERSION_Minor=2",
+            "OCTOVERSION_NuGetVersion=1.2.3",
+            "OCTOVERSION_Patch=3",
+            "OCTOVERSION_PreReleaseTag=",
+            "OCTOVERSION_PreReleaseTagWithDash=",
+        });
+    }
+}

--- a/source/OctoVersion.Tests/OctoVersionInfoFixture.cs
+++ b/source/OctoVersion.Tests/OctoVersionInfoFixture.cs
@@ -1,0 +1,37 @@
+using System.Linq;
+using OctoVersion.Core;
+using OctoVersion.Core.OutputFormatting.Environment;
+using OctoVersion.Core.VersionNumberCalculation;
+using Shouldly;
+using Xunit;
+
+namespace OctoVersion.Tests;
+
+public class OctoVersionInfoFixture
+{
+    [Fact]
+    public void GetPropertiesReadsPropertiesFromBothOctoVersionInfoAndBaseClass()
+    {
+        var octoVersionInfo = new OctoVersionInfo(1,2,3, string.Empty, string.Empty);
+
+        var properties = octoVersionInfo.GetProperties().ToArray();
+        
+        properties.ShouldContain(("FullSemVer", "1.2.3"), "we should read properties from OctoVersionInfo class");
+        properties.ShouldContain(("Major", "1"), "we should read properties from the base class, Semanticversion");
+    }
+    
+    [Fact]
+    public void ToStringRepresentationShowsTheFullSemVer()
+    {
+        var sampleData = new SampleDataBuilder()
+            .WithNonPreReleaseTags(new[] { "refs/heads/main" })
+            .WithNonPreReleaseTagsRegex(string.Empty)
+            .WithCurrentBranch("refs/heads/main")
+            .WithCurrentSha("a1b2c3d4e5")
+            .WithVersion(new SimpleVersion(1, 2, 3))
+            .WithExpectedInformationalVersion("1.2.3+Branch.main.Sha.a1b2c3d4e5");
+        var octoVersionInfo = sampleData.Build().ToOctoVersion();
+        
+        octoVersionInfo.ToString().ShouldBe("1.2.3", "we should get the full sem ver as the default string representation");
+    }
+}

--- a/source/OctoVersion.Tests/SampleData.cs
+++ b/source/OctoVersion.Tests/SampleData.cs
@@ -1,4 +1,5 @@
 using System;
+using OctoVersion.Core;
 using OctoVersion.Core.VersionNumberCalculation;
 
 namespace OctoVersion.Tests;
@@ -27,8 +28,8 @@ public class SampleData
         CurrentSha = currentSha ?? throw new ArgumentNullException(nameof(currentSha));
         OverriddenBuildMetadata = overriddenBuildMetadata;
         Version = version ?? throw new ArgumentNullException(nameof(version));
-        ExpectedInformationalVersion = expectedInformationalVersion ?? throw new ArgumentNullException(nameof(expectedInformationalVersion));
-        ExpectedFullSemVer = expectedFullSemVer ?? throw new ArgumentNullException(nameof(expectedFullSemVer));
+        ExpectedInformationalVersion = expectedInformationalVersion;
+        ExpectedFullSemVer = expectedFullSemVer;
     }
 
     public string[] NonPreReleaseTags { get; }
@@ -39,7 +40,20 @@ public class SampleData
     public string CurrentBranch { get; }
     public string CurrentSha { get; }
     public string? OverriddenBuildMetadata { get; }
-    public string ExpectedInformationalVersion { get; }
-    public string ExpectedFullSemVer { get; }
+    public string? ExpectedInformationalVersion { get; }
+    public string? ExpectedFullSemVer { get; }
     public SimpleVersion Version { get; }
+
+    public OctoVersionInfo ToOctoVersion()
+    {
+        var factory = new StructuredOutputFactory(NonPreReleaseTags,
+            NonPreReleaseTagsRegex,
+            OverriddenMajorVersion,
+            OverriddenMinorVersion,
+            OverriddenPatchVersion,
+            CurrentBranch,
+            CurrentSha,
+            OverriddenBuildMetadata);
+        return factory.Create(Version);
+    }
 }

--- a/source/OctoVersion.Tests/StructuredOutputFactoryFixture.cs
+++ b/source/OctoVersion.Tests/StructuredOutputFactoryFixture.cs
@@ -14,15 +14,7 @@ public class StructuredOutputFactoryFixture
     [MemberData(nameof(XUnitFormattedTestCases))]
     public void CalculatesOctoVersionCorrectly(SampleData sampleData)
     {
-        var factory = new StructuredOutputFactory(sampleData.NonPreReleaseTags,
-            sampleData.NonPreReleaseTagsRegex,
-            sampleData.OverriddenMajorVersion,
-            sampleData.OverriddenMinorVersion,
-            sampleData.OverriddenPatchVersion,
-            sampleData.CurrentBranch,
-            sampleData.CurrentSha,
-            sampleData.OverriddenBuildMetadata);
-        var result = factory.Create(sampleData.Version);
+        var result = sampleData.ToOctoVersion();
         result.InformationalVersion.ShouldBe(sampleData.ExpectedInformationalVersion);
         result.FullSemVer.ShouldBe(sampleData.ExpectedFullSemVer);
     }

--- a/source/OctoVersion.sln.DotSettings
+++ b/source/OctoVersion.sln.DotSettings
@@ -242,6 +242,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Nupkg/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Octo/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Octofront/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=OCTOVERSION/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=redirector/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=runbook/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=runbooks/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION
## Background

@corvette63 [reported](https://github.com/OctopusDeploy/OctoVersion/issues/98):

> documentation states output should be formatted such that
> 
> octoversion --CurrentBranch=main --OutputFormats:0=Environment
> 
> ```
> OCTOVERSION_Major=0
> OCTOVERSION_Minor=0
> OCTOVERSION_Patch=5
> OCTOVERSION_MajorMinorPatch=0.0.5
> OCTOVERSION_PreReleaseTag=
> OCTOVERSION_PreReleaseTagWithDash=
> OCTOVERSION_BuildMetadata=
> OCTOVERSION_BuildMetadataWithPlus=
> OCTOVERSION_FullSemVer=0.0.5
> ```
> 
> however actual output is such that
> 
> ```
> OCTOVERSION_PreReleaseTagWithDash: something
> OCTOVERSION_MajorMinorPatch: something
> OCTOVERSION_BuildMetadataWithPlus: something
> OCTOVERSION_FullSemVer: something
> OCTOVERSION_InformationalVersion: something
> OCTOVERSION_NuGetVersion: something
> ```

## Results

This PR includes the fix suggested in that issue, but also does a bit of refactoring to ensure the fix ends up in all formatters (the issue also affected TeamCity and GitHub Actions).

Fixes #98

@corvette63 - sorry it took us so long to get to this 😞. 