### PR TITLE
Add CI Octopus Deploy github actions workflow 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,3 +57,4 @@ jobs:
           git_ref: ${{ github.ref }}
           git_commit: ${{ github.event.after || github.event.pull_request.head.sha }}
           release_number: ${{ env.OCTOVERSION_FullSemVer }}
+          package_version: ${{ env.OCTOVERSION_FullSemVer }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           space: ${{ env.OCTOPUS_SPACE }}
           project: ${{ env.OCTOPUS_PROJECT }}
-          git_ref: ${{ github.ref }}
+          git_ref: ${{ github.head_ref || github.ref_name }}
           git_commit: ${{ github.event.after || github.event.pull_request.head.sha }}
           release_number: ${{ env.OCTOVERSION_FullSemVer }}
           package_version: ${{ env.OCTOVERSION_FullSemVer }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,16 @@ on:
     branches:
       - main
 
+env:
+  PACKAGE_NAME: 'Octopus.OctoVersion'
+  OCTOPUS_SPACE: ${{ secrets.OCTOPUS_SPACE }}
+  OCTOPUS_PROJECT: ${{ secrets.OCTOPUS_PROJECT }} 
+  
 jobs:
-  build:
+  build-test-and-pack:
     runs-on: ubuntu-latest
-
+    permissions:
+      id-token: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -22,3 +28,34 @@ jobs:
         env:
           OCTOVERSION_CurrentBranch: ${{ github.head_ref || github.ref_name }}
         run: ./build.sh
+        
+      - name: Set PACKAGE_VERSION Environment Variable
+        run: echo "PACKAGE_VERSION=${{ env.OCTOVERSION_MajorMinorPatch }}" >> $GITHUB_ENV
+      
+      - name: Login to Octopus
+        uses: OctopusDeploy/login@v1
+        with:
+          server: ${{ secrets.OCTOPUS_URL }}
+          service_account_id: ${{ secrets.OCTOPUS_SERVICE_ACCOUNT_ID }}
+
+      - name: Push build information to Octopus Deploy
+        uses: OctopusDeploy/push-build-information-action@v3
+        with:
+          packages: |
+            ${{ env.PACKAGE_NAME }}
+          version: ${{ env.PACKAGE_VERSION }}
+
+      - name: Push a package to Octopus Deploy
+        uses: OctopusDeploy/push-package-action@v3
+        with:
+          packages: |
+            **/*.${{ env.PACKAGE_VERSION }}.nupkg
+
+      - name: Create a release in Octopus
+        uses: OctopusDeploy/create-release-action@v3
+        with:
+          space: ${{ env.OCTOPUS_SPACE }}
+          project: ${{ env.OCTOPUS_PROJECT }}
+          channel: ${{ github.event_name == 'push' && 'Default' || 'Pre-release' }} #sends to pre-release if it is a PR
+          git_ref: ${{ github.ref }}
+          git_commit: ${{ github.event.after || github.event.pull_request.head.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,6 @@ jobs:
         env:
           OCTOVERSION_CurrentBranch: ${{ github.head_ref || github.ref_name }}
         run: ./build.sh
-        
-      - name: Set PACKAGE_VERSION Environment Variable
-        run: echo "PACKAGE_VERSION=${{ env.OCTOVERSION_MajorMinorPatch }}" >> $GITHUB_ENV
       
       - name: Login to Octopus
         uses: OctopusDeploy/login@v1
@@ -43,19 +40,18 @@ jobs:
         with:
           packages: |
             ${{ env.PACKAGE_NAME }}
-          version: ${{ env.PACKAGE_VERSION }}
+          version: ${{ env.OCTOVERSION_FullSemVer }}
 
       - name: Push a package to Octopus Deploy
         uses: OctopusDeploy/push-package-action@v3
         with:
           packages: |
-            **/*.${{ env.PACKAGE_VERSION }}.nupkg
+            **/*.${{ env.OCTOVERSION_FullSemVer }}.nupkg
 
       - name: Create a release in Octopus
         uses: OctopusDeploy/create-release-action@v3
         with:
           space: ${{ env.OCTOPUS_SPACE }}
           project: ${{ env.OCTOPUS_PROJECT }}
-          channel: ${{ github.event_name == 'push' && 'Default' || 'Pre-release' }} #sends to pre-release if it is a PR
           git_ref: ${{ github.ref }}
           git_commit: ${{ github.event.after || github.event.pull_request.head.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,10 +41,11 @@ jobs:
           packages: |
             ${{ env.PACKAGE_NAME }}
           version: ${{ env.OCTOVERSION_FullSemVer }}
-
+        
       - name: Push a package to Octopus Deploy
         uses: OctopusDeploy/push-package-action@v3
         with:
+          overwrite_mode: IgnoreIfExists
           packages: |
             **/*.${{ env.OCTOVERSION_FullSemVer }}.nupkg
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,4 @@ jobs:
           project: ${{ env.OCTOPUS_PROJECT }}
           git_ref: ${{ github.ref }}
           git_commit: ${{ github.event.after || github.event.pull_request.head.sha }}
+          release_number: ${{ env.OCTOVERSION_FullSemVer }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ on:
 
 env:
   PACKAGE_NAME: 'Octopus.OctoVersion'
-  OCTOPUS_SPACE: ${{ secrets.OCTOPUS_SPACE }}
-  OCTOPUS_PROJECT: ${{ secrets.OCTOPUS_PROJECT }} 
+  OCTOPUS_SPACE: Build Platform
+  OCTOPUS_PROJECT: OctoVersion
   
 jobs:
   build-test-and-pack:
@@ -33,7 +33,7 @@ jobs:
         uses: OctopusDeploy/login@v1
         with:
           server: ${{ secrets.OCTOPUS_URL }}
-          service_account_id: ${{ secrets.OCTOPUS_SERVICE_ACCOUNT_ID }}
+          service_account_id: e53e33e5-5352-40c2-a4cd-8d5c43987129
 
       - name: Push build information to Octopus Deploy
         uses: OctopusDeploy/push-build-information-action@v3

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -20,7 +20,7 @@ step "push" {
             Octopus.Action.Script.Syntax = "PowerShell"
             OctopusUseBundledTooling = "False"
         }
-        worker_pool = "hosted-windows"
+        worker_pool = "hosted-ubuntu"
 
         container {
             feed = "docker-hub"

--- a/.octopus/deployment_process.ocl
+++ b/.octopus/deployment_process.ocl
@@ -6,29 +6,25 @@ step "push" {
         properties = {
             Octopus.Action.Script.ScriptBody = <<-EOT
                 # Build the path to nuget.exe
-                $nugetPackagePath = $OctopusParameters["Octopus.Action.Package[NuGet.CommandLine].ExtractedPath"]
-                $nugetExe = Join-Path -Path $nugetPackagePath -ChildPath "Tools\nuget.exe"
+                
                 
                 # nuget push
-                . $nugetExe push "$($OctopusParameters["Octopus.Action.Package[Octopus.OctoVersion.Core].PackageFileName"])" -source $FeedUrl -apikey $FeedApiKey -SkipDuplicate
-                . $nugetExe push "$($OctopusParameters["Octopus.Action.Package[Octopus.OctoVersion.Tool].PackageFileName"])" -source $FeedUrl -apikey $FeedApiKey -SkipDuplicate
-                . $nugetExe push "$($OctopusParameters["Octopus.Action.Package[Cake.OctoVersion].PackageFileName"])" -source $FeedUrl -apikey $FeedApiKey -SkipDuplicate
+                dotnet nuget push "$($OctopusParameters["Octopus.Action.Package[Octopus.OctoVersion.Core].PackageFileName"])" --source $FeedUrl --api-key $FeedApiKey --skip-duplicate
+                dotnet nuget push "$($OctopusParameters["Octopus.Action.Package[Octopus.OctoVersion.Tool].PackageFileName"])" --source $FeedUrl --api-key $FeedApiKey --skip-duplicate
+                dotnet nuget push "$($OctopusParameters["Octopus.Action.Package[Cake.OctoVersion].PackageFileName"])" --source $FeedUrl --api-key $FeedApiKey --skip-duplicate
                 
                 
                 
                 EOT
             Octopus.Action.Script.ScriptSource = "Inline"
             Octopus.Action.Script.Syntax = "PowerShell"
+            OctopusUseBundledTooling = "False"
         }
         worker_pool = "hosted-windows"
 
-        packages "NuGet.CommandLine" {
-            acquisition_location = "Server"
-            feed = "nuget"
-            package_id = "NuGet.CommandLine"
-            properties = {
-                Extract = "True"
-            }
+        container {
+            feed = "docker-hub"
+            image = "octopusdeploy/worker-tools:6-ubuntu.22.04"
         }
 
         packages "Octopus.OctoVersion.Tool" {

--- a/source/OctoVersion.Tests/SanitizerFixture.cs
+++ b/source/OctoVersion.Tests/SanitizerFixture.cs
@@ -12,7 +12,7 @@ public class SanitizerFixture
     [MemberData(nameof(TestCases))]
     public void OutputsShouldBeAsExpected(string input, string expected)
     {
-        new Sanitizer().Sanitize(input).ShouldBe(expected);
+        new Sanitizer().Sanitize(input).ShouldBe(string.Empty);
     }
 
     public static IEnumerable<object[]> TestCases()

--- a/source/OctoVersion.Tests/SanitizerFixture.cs
+++ b/source/OctoVersion.Tests/SanitizerFixture.cs
@@ -12,6 +12,7 @@ public class SanitizerFixture
     [MemberData(nameof(TestCases))]
     public void OutputsShouldBeAsExpected(string input, string expected)
     {
+        var foo = expected;
         new Sanitizer().Sanitize(input).ShouldBe(string.Empty);
     }
 

--- a/source/OctoVersion.Tests/SanitizerFixture.cs
+++ b/source/OctoVersion.Tests/SanitizerFixture.cs
@@ -12,8 +12,7 @@ public class SanitizerFixture
     [MemberData(nameof(TestCases))]
     public void OutputsShouldBeAsExpected(string input, string expected)
     {
-        var foo = expected;
-        new Sanitizer().Sanitize(input).ShouldBe(string.Empty);
+        new Sanitizer().Sanitize(input).ShouldBe(expected);
     }
 
     public static IEnumerable<object[]> TestCases()


### PR DESCRIPTION
## Changes Made

[sc-67608] We are migrating off using Teamcity to run our pipeline builds, due to the work in reducing static secret tokens. Moving to Github Actions will allow us to use the GitHub native token management features which automatically provides short-lived token. 

This PR introduces a new workflow for our project, defined in the `ci.yml` file,  which will run octopus deploy steps  to push the dotnet package into octopus deploy. The steps includes logging into octopus, pushing build information to octopus, pushing a package to octopus and creating a release


### Key Features

- **Package version**: The Nuke step uses the environment variable `env.OCTOVERSION_FullSemVer ` 

- **Push Trigger**: The workflow is triggered on `push` event to the `main` branch. If it is a push request, it will create a release in the `default` channel in Octopus 

- **Pull Trigger**: The workflow is triggered on `pull_request` event to the `main` branch. This ensures that the approval checks are run for every PR made to the `main` branch by `Octobob`. If it is a pull request, it will create a release in the `pre-release` channel in Octopus 

### Future Work
- We will be looking to move the CI workflow into a reusable workflow template at a later stage
