### PR TITLE
Update to octoversion config to use main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           overwrite_mode: IgnoreIfExists
           packages: |
-            **/*.${{ env.OCTOVERSION_FullSemVer }}.nupkg
+            artifacts/*.${{ env.OCTOVERSION_FullSemVer }}.nupkg
 
       - name: Create a release in Octopus
         uses: OctopusDeploy/create-release-action@v3

--- a/.octopus/variables.ocl
+++ b/.octopus/variables.ocl
@@ -23,7 +23,3 @@ variable "FeedUrl" {
 variable "Slack.DeploymentNotificationChannel" {
     value "#feed-build-platform-alerts" {}
 }
-
-variable "Octopus.Acquire.DeltaCompressionEnabled" {
-    value "false" {}
-}

--- a/.octopus/variables.ocl
+++ b/.octopus/variables.ocl
@@ -23,3 +23,7 @@ variable "FeedUrl" {
 variable "Slack.DeploymentNotificationChannel" {
     value "#feed-build-platform-alerts" {}
 }
+
+variable "Octopus.Acquire.DeltaCompressionEnabled" {
+    value "false" {}
+}

--- a/octoversion.json
+++ b/octoversion.json
@@ -1,3 +1,3 @@
 {
-    "NonPreReleaseTags": ["main"]
+    "NonPreReleaseTags": ["refs/heads/main", "main"]
 }

--- a/octoversion.json
+++ b/octoversion.json
@@ -1,3 +1,3 @@
 {
-    "NonPreReleaseTags": ["refs/heads/main"]
+    "NonPreReleaseTags": ["main"]
 }


### PR DESCRIPTION
In Octopus, the the main branch is getting released into pre-release. This PR updates the 'main' branch so that it correctly sends it to the production channel 