### PR TITLE
Update package version branch naming based on schedule trigger & git tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,21 @@ jobs:
           
       - name: Run Nuke
         run: ./build.sh
-      
+
+      - name: Git Tag (when not pre-release)
+        id: github-tag
+        if: ${{ !contains( env.OCTOVERSION_FullSemVer, '-' ) }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: "refs/tags/${{ env.OCTOVERSION_FullSemVer }}",
+              sha: context.sha
+            })
+
       - name: Login to Octopus
         uses: OctopusDeploy/login@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Run Nuke
         env:
-          OCTOVERSION_CurrentBranch: ${{ github.head_ref || github.ref_name }}
+          OCTOVERSION_CurrentBranch: ${{ github.event_name == 'schedule' &&  'scheduledRun' || ( github.head_ref || github.ref_name) }}
         run: ./build.sh
       
       - name: Login to Octopus
@@ -55,13 +55,10 @@ jobs:
 
       - name: Create a release in Octopus
         uses: OctopusDeploy/create-release-action@v3
-        env: 
-          OCTOVERSION_ScheduledSemVer: ${{ env.OCTOVERSION_MajorMinorPatch }}-scheduledRun
         with:
           space: ${{ env.OCTOPUS_SPACE }}
           project: ${{ env.OCTOPUS_PROJECT }}
           git_ref: ${{ github.head_ref || github.ref_name }}
           git_commit: ${{ github.event.after || github.event.pull_request.head.sha }}
-          release_number: ${{ github.event_name == 'schedule' &&  env.OCTOVERSION_ScheduledSemVer || env.OCTOVERSION_FullSemVer }}
+          release_number: ${{ env.OCTOVERSION_FullSemVer }}
           package_version: ${{ env.OCTOVERSION_FullSemVer }}
-          channel: ${{ github.event_name == 'schedule' &&  'Pre-release' || ''}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,8 @@ env:
   PACKAGE_NAME: 'Octopus.OctoVersion'
   OCTOPUS_SPACE: Build Platform
   OCTOPUS_PROJECT: OctoVersion
-  
+  OCTOVERSION_CurrentBranch: ${{ github.head_ref || github.ref_name }}
+
 jobs:
   build-test-and-pack:
     runs-on: ubuntu-latest
@@ -27,10 +28,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
+      
+      - name: Append OCTOVERSION_CurrentBranch with -nightly-<timestamp> (for scheduled)
+        if: github.event_name == 'schedule'
+        run: |
+          echo "OCTOVERSION_CurrentBranch=${{ env.OCTOVERSION_CurrentBranch }}-nightly-$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
+          
       - name: Run Nuke
-        env:
-          OCTOVERSION_CurrentBranch: ${{ github.event_name == 'schedule' &&  'scheduledRun' || ( github.head_ref || github.ref_name) }}
         run: ./build.sh
       
       - name: Login to Octopus


### PR DESCRIPTION
Error with previous action run: 
`Error: At least one step violates the package version rules for the Channel 'Pre-release'. Either correct the package versions for this release, let Octopus select the best channel by omitting the ChannelName argument, select a different channel using the ChannelName argument, or ignore these version rules altogether by using the IgnoreChannelRules argument.`

Channel rules are based off package version rules. This PR removes the channel rules and updates the package version environment branch name based on whether the GitHub action was a scheduled run or not. This way, scheduled runs are sorted into the 'pre-release' environment by default 

In addition, git tags are added for all releases from the main branch (non pre-release)