### PR TITLE
Update github token permissions to create git tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
   build-test-and-pack:
     runs-on: ubuntu-latest
     permissions:
-      id-token: write
+      id-token: write # Required to obtain the ID token from GitHub Actions
+      contents: write # Read Required to check out code, Write to create Git Tags
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Update write content permission to enable git tag creation on main 