### PR TITLE
Close any existing open PRs

### DIFF
--- a/.github/workflows/prettybot-automation.yml
+++ b/.github/workflows/prettybot-automation.yml
@@ -64,4 +64,10 @@ jobs:
             - name: Create Pull Request
               if: steps.git-check.outputs.changed == 'true'
               run: |
-                  gh pr create --base main --head ${{ env.BRANCH_NAME }} --title "Automated PR for Prettybot" --body "This is an automated PR."
+                EXISTING_PRS=$(gh pr list --author "github-actions[bot]" --state open --head "prettybot" --json number --template '{{range .}}{{.number}}{{ "\n" }}{{end}}')
+                NEW_PR=$(gh pr create --base main --head ${{ env.BRANCH_NAME }} --title "Automated PR for Prettybot" --body "This is an automated PR.")
+                # close existing PRs
+                for pr in $EXISTING_PRS; do
+                  gh pr close "$pr" --comment "Superseded by $NEW_PR." --delete-branch
+                done
+  

--- a/.github/workflows/prettybot-automation.yml
+++ b/.github/workflows/prettybot-automation.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: # Add manual trigger
 
 # Increase the access for the GITHUB_TOKEN
 permissions:


### PR DESCRIPTION
The github PrettyBot workflow creates new PRs, but doesn't close the old ones.
This means if we cant get to them straight away, they stack up.