### PR TITLE
Allow manual trigger of CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
     # Every week we check the pipeline
     # 2330 UTC Sunday == 0930 AEST Monday
     - cron: '30 23 * * 0'
+  workflow_dispatch: # Add manual trigger
 
 env:
   PACKAGE_NAME: 'Octopus.OctoVersion'


### PR DESCRIPTION
So we can run the prettybot builds manually

(we're likely to have to write code to trigger an actions run as github wont run an new action based on something created by an action) 