### PR TITLE
Remove support for net6.0 and net7.0

### DIFF
--- a/source/Cake.OctoVersion/Cake.OctoVersion.csproj
+++ b/source/Cake.OctoVersion/Cake.OctoVersion.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Version>0.0.0</Version>
 		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/source/OctoVersion.Core/OctoVersion.Core.csproj
+++ b/source/OctoVersion.Core/OctoVersion.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+		<TargetFramework>net8.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
 		<Nullable>enable</Nullable>
 		<Version>0.0.0</Version>

--- a/source/OctoVersion.Tests/OctoVersion.Tests.csproj
+++ b/source/OctoVersion.Tests/OctoVersion.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>

--- a/source/OctoVersion.Tool/OctoVersion.Tool.csproj
+++ b/source/OctoVersion.Tool/OctoVersion.Tool.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+		<TargetFramework>net8.0</TargetFramework>
 		<PackAsTool>true</PackAsTool>
 		<ToolCommandName>octoversion</ToolCommandName>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
net6.0 is EOL on November 12, 2024, so we want to remove it
net7.0 is already EOL

[sc-90596]

+semver: breaking