### PR TITLE
Be a bit more lenient with parsing semver bumps

### DIFF
--- a/source/OctoVersion.Core/ExtensionMethods/CommitExtensionMethods.cs
+++ b/source/OctoVersion.Core/ExtensionMethods/CommitExtensionMethods.cs
@@ -6,20 +6,8 @@ namespace OctoVersion.Core.ExtensionMethods;
 static class CommitExtensionMethods
 {
     public static bool BumpsMajorVersion(this Commit commit)
-    {
-        if (commit.Message == null) return false;
-
-        if (commit.Message.Contains("+semver: breaking")) return true;
-        if (commit.Message.Contains("+semver: major")) return true;
-        return false;
-    }
+        => commit.Message.CommitMessageBumpsMajorVersion();
 
     public static bool BumpsMinorVersion(this Commit commit)
-    {
-        if (commit.Message == null) return false;
-
-        if (commit.Message.Contains("+semver: feature")) return true;
-        if (commit.Message.Contains("+semver: minor")) return true;
-        return false;
-    }
+        => commit.Message.CommitMessageBumpsMinorVersion();
 }

--- a/source/OctoVersion.Core/ExtensionMethods/StringExtensionMethods.cs
+++ b/source/OctoVersion.Core/ExtensionMethods/StringExtensionMethods.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace OctoVersion.Core.ExtensionMethods
+{
+    static class StringExtensionMethods
+    {
+        public static bool CommitMessageBumpsMajorVersion(this string? commitMessage)
+        {
+            if (commitMessage == null) return false;
+
+            var normalizedCommitMessage = commitMessage.Replace(" ", "");
+            if (normalizedCommitMessage.Contains("+semver:breaking", StringComparison.OrdinalIgnoreCase)) return true;
+            if (normalizedCommitMessage.Contains("+semver:major", StringComparison.OrdinalIgnoreCase)) return true;
+            return false;
+        }
+        public static bool CommitMessageBumpsMinorVersion(this string? commitMessage)
+        {
+            if (commitMessage == null) return false;
+            var normalizedCommitMessage = commitMessage.Replace(" ", "");
+            if (normalizedCommitMessage.Contains("+semver:feature", StringComparison.OrdinalIgnoreCase)) return true;
+            if (normalizedCommitMessage.Contains("+semver:minor", StringComparison.OrdinalIgnoreCase)) return true;
+            return false;
+        }
+    }
+}

--- a/source/OctoVersion.Tests/WhenParsingCommitMessages.cs
+++ b/source/OctoVersion.Tests/WhenParsingCommitMessages.cs
@@ -1,0 +1,43 @@
+using System;
+using LibGit2Sharp;
+using OctoVersion.Core.ExtensionMethods;
+using Shouldly;
+using Xunit;
+
+namespace OctoVersion.Tests
+{
+    public class WhenParsingCommitMessages
+    {
+        [Theory]
+        [InlineData("This is a commit message", false)]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData("This is a commit message +semver: breaking", true)]
+        [InlineData("This is a commit message +semver:breaking", true)]
+        [InlineData("This is a commit message +SemVer:Breaking", true)]
+        [InlineData("This is a commit message +semver: major", true)]
+        [InlineData("This is a commit message +semver:major", true)]
+        [InlineData("This is a commit message +SemVer:Major", true)]
+        public void ParsesMajorVersionBumpCorrectly(string? commitMessage, bool expectedResult)
+        {
+            var result = commitMessage.CommitMessageBumpsMajorVersion();
+            result.ShouldBe(expectedResult);
+        }
+        
+        [Theory]
+        [InlineData(null, false)]
+        [InlineData("", false)]
+        [InlineData("This is a commit message", false)]
+        [InlineData("This is a commit message +semver: feature", true)]
+        [InlineData("This is a commit message +semver:feature", true)]
+        [InlineData("This is a commit message +SemVer:Feature", true)]
+        [InlineData("This is a commit message +semver: minor", true)]
+        [InlineData("This is a commit message +semver:minor", true)]
+        [InlineData("This is a commit message +SemVer:Minor", true)]
+        public void ParsesMinorVersionBumpCorrectly(string? commitMessage, bool expectedResult)
+        {
+            var result = commitMessage.CommitMessageBumpsMinorVersion();
+            result.ShouldBe(expectedResult);
+        }
+    }
+}


### PR DESCRIPTION
In the past, I've been bitten by trying to go `+semver:breaking`, which didn't work, because it expected a space.

This PR makes the parsing a bit more lenient, allowing spaces and different character cases  