### PR TITLE
Update build tooling to .net9, tests and tool target both net8 and net9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-            
+
       - name: Append OCTOVERSION_CurrentBranch with -nightly-<timestamp> (for scheduled)
         if: github.event_name == 'schedule'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,15 +27,22 @@ jobs:
       contents: write # Read Required to check out code, Write to create Git Tags
       statuses: write # Required to send commit status checks
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+            
       - name: Append OCTOVERSION_CurrentBranch with -nightly-<timestamp> (for scheduled)
         if: github.event_name == 'schedule'
         run: |
           echo "OCTOVERSION_CurrentBranch=${{ env.OCTOVERSION_CurrentBranch }}-nightly-$(date +'%Y%m%d%H%M%S')" >> $GITHUB_ENV
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
           
       - name: Run Nuke
         run: ./build.sh

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -9,7 +9,15 @@
     <NukeScriptDirectory>..</NukeScriptDirectory>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <NukeTelemetryVersion>1</NukeTelemetryVersion>
+    <!-- NET8/9: Nuke 8.x uses BinaryFormatter which is blocked without this flag.
+     see https://github.com/nuke-build/nuke/issues/1282 -->
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
+    <!-- Restore insecure BinaryFormatter package until we can move to Nuke 9 which doesn't need it -->
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="9.0.0" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="8.1.4" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/source/OctoVersion.Tests/OctoVersion.Tests.csproj
+++ b/source/OctoVersion.Tests/OctoVersion.Tests.csproj
@@ -1,12 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    <LangVersion>10</LangVersion>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <LangVersion>10</LangVersion>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/OctoVersion.Tool/OctoVersion.Tool.csproj
+++ b/source/OctoVersion.Tool/OctoVersion.Tool.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 		<PackAsTool>true</PackAsTool>
 		<ToolCommandName>octoversion</ToolCommandName>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
# Background

OctoVersion is used for Octopus Server, which will soon be upgraded to .NET 9.
When this happens, the octonotes dotnet tool will start running in an environment where the `global.json` specifies .NET 9, so we'll need a .NET 9 compatible tool version.

# Results
- Updates `global.json` and the GHA build script to compile with the .NET 9 SDK
- Tests are dual-run against both net8 and net9
- Libraries (dll's) have been left targeting netstandard or net8. The TargetFramework in this context specifies the minimum .NET version required; we need to keep this on net8 so long as it is supported.
- The dotnet tool package now dual-targets net8 and net9. This produces a nuget package with both versions (screenshot below), which will enable the octopus server upgrade

![image](https://github.com/user-attachments/assets/032a42cf-55a8-42ab-be31-4aae8c651f74)

