### PR TITLE
Switch to fork of Nuke [BLD-2686]

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <!-- https://github.com/microsoft/MSBuildLocator/blob/main/docs/diagnostics/MSBL001.md -->
+    <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="10.1.0" />
+    <PackageReference Include="Octopus.Nuke.Common" Version="10.1.25" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes build issue with CVE reports due to old, unmaintained public Nuke version.