### PR TITLE
Fix nuget sources

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -13,8 +13,9 @@
         </packageSource>
         <packageSource key="NuGet.org v3">
             <package pattern="*" />
-            <!-- This specific package is newer on NuGet.org for some reason -->
+            <!-- These specific packages are on NuGet.org -->
             <package pattern="Octopus.Shellfish" />
+            <package pattern="Octopus.OctoVersion.Tool" />
         </packageSource>
     </packageSourceMapping>
 </configuration>

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,8 +2,19 @@
 
 <configuration>
     <packageSources>
+        <clear />
         <add key="NuGet.org v3" value="https://api.nuget.org/v3/index.json" />
         <add key="feedz.io" value="https://f.feedz.io/octopus-deploy/dependencies/nuget" />
-        <add key="nuget.packages.octopushq.com" value="https://nuget.packages.octopushq.com/" />
     </packageSources>
+    
+    <packageSourceMapping>
+        <packageSource key="feedz.io">
+            <package pattern="Octopus.*" />
+        </packageSource>
+        <packageSource key="NuGet.org v3">
+            <package pattern="*" />
+            <!-- This specific package is newer on NuGet.org for some reason -->
+            <package pattern="Octopus.Shellfish" />
+        </packageSource>
+    </packageSourceMapping>
 </configuration>


### PR DESCRIPTION
Dependabot is struggling because of some problem searching for `Microsoft.*` packages on Feedz.

This PR pins packages to their appropriate sources using [Package Source Mapping](https://learn.microsoft.com/en-us/nuget/consume-packages/package-source-mapping).