### PR TITLE
Don't truncate the NuGet pre-release tag onto a trailing dot

### DIFF
--- a/source/OctoVersion.Core/OctoVersionInfo.cs
+++ b/source/OctoVersion.Core/OctoVersionInfo.cs
@@ -40,8 +40,18 @@ public class OctoVersionInfo : SemanticVersion
     public string BuildMetadataWithPlus => string.IsNullOrWhiteSpace(BuildMetadata) ? string.Empty : $"+{InvalidBuildMetadataCharacters.Replace(BuildMetadata, "-")}";
     public string FullSemVer => $"{MajorMinorPatch}{PreReleaseTagWithDash}";
     public string InformationalVersion => $"{MajorMinorPatch}{PreReleaseTagWithDash}{BuildMetadataWithPlus}";
-    string NuGetCompatiblePreReleaseWithDash => PreReleaseTagWithDash.Substring(0, Math.Min(PreReleaseTagWithDash.Length, 20));
     public string NuGetVersion => $"{MajorMinorPatch}{NuGetCompatiblePreReleaseWithDash}";
+
+    string NuGetCompatiblePreReleaseWithDash
+    {
+        get
+        {
+            var truncated = PreReleaseTagWithDash.Substring(0, Math.Min(PreReleaseTagWithDash.Length, 20));
+
+            //a trailing dot is an empty pre-release identifier, which is not a valid version
+            return truncated.TrimEnd('.');
+        }
+    }
 
     public override string ToString()
     {

--- a/source/OctoVersion.Tests/WhenStringifyingAnOctoVersionInfo.cs
+++ b/source/OctoVersion.Tests/WhenStringifyingAnOctoVersionInfo.cs
@@ -44,6 +44,13 @@ public class WhenStringifyingAnOctoVersionInfo
         "dependabot/npm_and_yarn/source/TentacleArmy.Web/ini-1.3.6",
         "Branch.dependabot/npm_and_yarn/source/TentacleArmy.Web/ini-1.3.6.Sha.069392d9d2d37ddb6009998b92e70963badcc666");
 
+    //the NuGet-compatible pre-release is 20 characters, which lands this one exactly on a dot
+    static readonly OctoVersionInfo VersionWhereTheNuGetTruncationLandsOnADot = new(1,
+        1,
+        47,
+        "renovate-microsoft.aspnetcore.mvc.newtonsoftjson-10.x",
+        "Branch.renovate-microsoft.aspnetcore.mvc.newtonsoftjson-10.x.Sha.72529493c8ccfae2784cd604b7784294b03f388d");
+
     //xunit is blurgh - IEnumerable of object[]? ick.
     public static IEnumerable<object[]> PreReleaseTagWithDashTestCases()
     {
@@ -54,6 +61,7 @@ public class WhenStringifyingAnOctoVersionInfo
         yield return new object[] { VersionWithPreReleaseTagAndBuildMetadata, "-pre", "it should append the pre-release tag, but not the build metadata" };
         yield return new object[] { VersionWithLongPreReleaseTagAndBuildMetadata, "-mark-genericDocumentStore", "it should add the pre-release tag, and ignore the build metadata" };
         yield return new object[] { VersionWithLongPreReleaseTagWithSlashesAndBuildMetadata, "-dependabot-npm-and-yarn-source-TentacleArmy.Web-ini-1.3.6", "it should add the pre-release tag, and ignore the build metadata" };
+        yield return new object[] { VersionWhereTheNuGetTruncationLandsOnADot, "-renovate-microsoft.aspnetcore.mvc.newtonsoftjson-10.x", "it should add the pre-release tag untruncated" };
     }
 
     [Theory]
@@ -108,6 +116,7 @@ public class WhenStringifyingAnOctoVersionInfo
         yield return new object[] { VersionWithPreReleaseTagAndBuildMetadata, "1.2.3-pre", "it should return the major.minor.patch and pre-release but not the build metadata" };
         yield return new object[] { VersionWithLongPreReleaseTagAndBuildMetadata, "2021.1.3-mark-genericDocumentStore", "it should return the major.minor.patch and pre-release but not the build metadata" };
         yield return new object[] { VersionWithLongPreReleaseTagWithSlashesAndBuildMetadata, "2021.1.3-dependabot-npm-and-yarn-source-TentacleArmy.Web-ini-1.3.6", "it should return the major.minor.patch and pre-release but not the build metadata" };
+        yield return new object[] { VersionWhereTheNuGetTruncationLandsOnADot, "1.1.47-renovate-microsoft.aspnetcore.mvc.newtonsoftjson-10.x", "it should return the major.minor.patch and the untruncated pre-release" };
     }
 
     [Theory]
@@ -126,6 +135,7 @@ public class WhenStringifyingAnOctoVersionInfo
         yield return new object[] { VersionWithPreReleaseTagAndBuildMetadata, "1.2.3-pre", "it should return the major.minor.patch and pre-release but not the build metadata" };
         yield return new object[] { VersionWithLongPreReleaseTagAndBuildMetadata, "2021.1.3-mark-genericDocumen", "it should return the major.minor.patch and trim the pre-release to 20 chars" };
         yield return new object[] { VersionWithLongPreReleaseTagWithSlashesAndBuildMetadata, "2021.1.3-dependabot-npm-and-", "it should return the major.minor.patch and trim the pre-release to 20 chars" };
+        yield return new object[] { VersionWhereTheNuGetTruncationLandsOnADot, "1.1.47-renovate-microsoft", "a trimmed pre-release must not end with a dot" };
     }
 
     [Theory]
@@ -144,6 +154,7 @@ public class WhenStringifyingAnOctoVersionInfo
         yield return new object[] { VersionWithPreReleaseTagAndBuildMetadata, "1.2.3-pre+build", "it should return the major.minor.patch and pre-release and build metadata" };
         yield return new object[] { VersionWithLongPreReleaseTagAndBuildMetadata, "2021.1.3-mark-genericDocumentStore+Branch.mark-genericDocumentStore.Sha.fb13016f3a21d7c2058fb74ab25f19e5311c6550", "it should return the major.minor.patch and pre-release and build metadata" };
         yield return new object[] { VersionWithLongPreReleaseTagWithSlashesAndBuildMetadata, "2021.1.3-dependabot-npm-and-yarn-source-TentacleArmy.Web-ini-1.3.6+Branch.dependabot-npm-and-yarn-source-TentacleArmy.Web-ini-1.3.6.Sha.069392d9d2d37ddb6009998b92e70963badcc666", "it should return the major.minor.patch and pre-release and build metadata" };
+        yield return new object[] { VersionWhereTheNuGetTruncationLandsOnADot, "1.1.47-renovate-microsoft.aspnetcore.mvc.newtonsoftjson-10.x+Branch.renovate-microsoft.aspnetcore.mvc.newtonsoftjson-10.x.Sha.72529493c8ccfae2784cd604b7784294b03f388d", "it should return the major.minor.patch and pre-release and build metadata" };
     }
 
     [Theory]


### PR DESCRIPTION
[DPT-3106](https://linear.app/octopus/issue/DPT-3106/octoversion-emits-an-invalid-version-when-the-nuget-pre-release-tag)

## Why

`NuGetVersion` truncates the branch-derived pre-release tag to 20 characters. The cut is unaware of SemVer identifier boundaries, so when it lands on a `.` the emitted version ends with an empty identifier and is not a valid version string.

This broke [Slipway#2356](https://github.com/OctopusDeploy/Slipway/pull/2356) — branch `renovate/microsoft.aspnetcore.mvc.newtonsoftjson-10.x` yields `-renovate-microsoft.`, exactly 20 characters, and the build fails with `error NETSDK1018: Invalid NuGet version string`. [Slipway#2360](https://github.com/OctopusDeploy/Slipway/pull/2360) works around it in that repo's workflow; the invalid string originates here, so every consumer is exposed. Once this ships, that PR can drop the workaround and keep only its `branchNameStrict` change.

## Notes

All 20 characters are still used where they are valid, so every currently-valid output is unchanged — including cuts that land mid-identifier, and cuts that leave a trailing hyphen (a hyphen is a legal identifier character; only the dot breaks).

Two other ways to emit an invalid version turned up while verifying this, both deliberately left alone. A numeric pre-release identifier with a leading zero is invalid, so branch `mattr/fix.0123` produces a version the SDK rejects, in `FullSemVer` as well as `NuGetVersion`; truncation can also create the case by cutting `0123abc` down to `012`. Fixing either means rewriting the user's digits so the version no longer matches the branch it came from, which isn't worth it — a branch name that trips this needs renaming.

Verified against the real SDK: `dotnet build -p:Version=1.1.47-renovate-microsoft.` fails, `-renovate-microsoft` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)